### PR TITLE
Feature/support tvm in dnn

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(ION_BUNDLE_HALIDE "Enable to bundle Halide binary into package" OFF)
 #TODO: Enable define HALIDE_FOR_FPGA into compile option if it is ON
 option(ION_ENABLE_HALIDE_FPGA_BACKEND "Enable to Halide FPGA backend" OFF)
 option(WITH_CUDA "Enable CUDA with buliding examples." ON)
+option(WITH_TVM "Use TVM in ion-bb-dnn." ON)
 
 #
 # CMake common settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ option(ION_BUNDLE_HALIDE "Enable to bundle Halide binary into package" OFF)
 #TODO: Enable define HALIDE_FOR_FPGA into compile option if it is ON
 option(ION_ENABLE_HALIDE_FPGA_BACKEND "Enable to Halide FPGA backend" OFF)
 option(WITH_CUDA "Enable CUDA with buliding examples." ON)
-option(WITH_TVM "Use TVM in ion-bb-dnn." ON)
 
 #
 # CMake common settings

--- a/example/dnn_compile.cc
+++ b/example/dnn_compile.cc
@@ -19,7 +19,7 @@ int main(int argc, char *argv[]) {
         n = b.add("image_io_image_loader").set_param(Param{"url", "http://ion-archives.s3-us-west-2.amazonaws.com/pedestrian.jpg"});
         n = b.add("core_normalize_3d_uint8")(n["output"]);
         n = b.add("core_reorder_buffer_3d_float")(n["output"]).set_param(Param{"dim0", "2"}, Param{"dim1", "0"}, Param{"dim2", "1"});  // CHW -> HWC
-        n = b.add("dnn_object_detection")(n["output"]);
+        n = b.add("dnn_object_detection")(n["output"]).set_param(Param{"dnn_model_kind", "ssd_mobilenet_v1_coco"});
         n = b.add("core_denormalize_3d_uint8")(n["output"]);
 
         b.compile("dnn");

--- a/example/dnn_run.cc
+++ b/example/dnn_run.cc
@@ -22,6 +22,11 @@ int main(int argc, char *argv[]) {
         dnn(out_buf);
         halide_profiler_reset();
 
+        const int iter = 5;
+        for (int i = 0; i < iter; ++i) {
+            dnn(out_buf);
+        }
+
         cv::Mat predicted(input_height, input_width, CV_8UC3, out_buf.data());
         cv::imwrite("predicted.png", predicted);
 

--- a/include/ion-bb-dnn/3rdparty/dlpack/dlpack.h
+++ b/include/ion-bb-dnn/3rdparty/dlpack/dlpack.h
@@ -1,0 +1,174 @@
+/*!
+ *  Copyright (c) 2017 by Contributors
+ * \file dlpack.h
+ * \brief The common header of DLPack.
+ */
+#ifndef DLPACK_DLPACK_H_
+#define DLPACK_DLPACK_H_
+
+#ifdef __cplusplus
+#define DLPACK_EXTERN_C extern "C"
+#else
+#define DLPACK_EXTERN_C
+#endif
+
+/*! \brief The current version of dlpack */
+#define DLPACK_VERSION 020
+
+/*! \brief DLPACK_DLL prefix for windows */
+#ifdef _WIN32
+#ifdef DLPACK_EXPORTS
+#define DLPACK_DLL __declspec(dllexport)
+#else
+#define DLPACK_DLL __declspec(dllimport)
+#endif
+#else
+#define DLPACK_DLL
+#endif
+
+#include <stdint.h>
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*!
+ * \brief The device type in DLContext.
+ */
+typedef enum {
+  /*! \brief CPU device */
+  kDLCPU = 1,
+  /*! \brief CUDA GPU device */
+  kDLGPU = 2,
+  /*!
+   * \brief Pinned CUDA GPU device by cudaMallocHost
+   * \note kDLCPUPinned = kDLCPU | kDLGPU
+   */
+  kDLCPUPinned = 3,
+  /*! \brief OpenCL devices. */
+  kDLOpenCL = 4,
+  /*! \brief Vulkan buffer for next generation graphics. */
+  kDLVulkan = 7,
+  /*! \brief Metal for Apple GPU. */
+  kDLMetal = 8,
+  /*! \brief Verilog simulator buffer */
+  kDLVPI = 9,
+  /*! \brief ROCm GPUs for AMD GPUs */
+  kDLROCM = 10,
+  /*!
+   * \brief Reserved extension device type,
+   * used for quickly test extension device
+   * The semantics can differ depending on the implementation.
+   */
+  kDLExtDev = 12,
+} DLDeviceType;
+
+/*!
+ * \brief A Device context for Tensor and operator.
+ */
+typedef struct {
+  /*! \brief The device type used in the device. */
+  DLDeviceType device_type;
+  /*! \brief The device index */
+  int device_id;
+} DLContext;
+
+/*!
+ * \brief The type code options DLDataType.
+ */
+typedef enum {
+  kDLInt = 0U,
+  kDLUInt = 1U,
+  kDLFloat = 2U,
+  kDLBfloat = 4U,
+} DLDataTypeCode;
+
+/*!
+ * \brief The data type the tensor can hold.
+ *
+ *  Examples
+ *   - float: type_code = 2, bits = 32, lanes=1
+ *   - float4(vectorized 4 float): type_code = 2, bits = 32, lanes=4
+ *   - int8: type_code = 0, bits = 8, lanes=1
+ */
+typedef struct {
+  /*!
+   * \brief Type code of base types.
+   * We keep it uint8_t instead of DLDataTypeCode for minimal memory
+   * footprint, but the value should be one of DLDataTypeCode enum values.
+   * */
+  uint8_t code;
+  /*!
+   * \brief Number of bits, common choices are 8, 16, 32.
+   */
+  uint8_t bits;
+  /*! \brief Number of lanes in the type, used for vector types. */
+  uint16_t lanes;
+} DLDataType;
+
+/*!
+ * \brief Plain C Tensor object, does not manage memory.
+ */
+typedef struct {
+  /*!
+   * \brief The opaque data pointer points to the allocated data. This will be
+   * CUDA device pointer or cl_mem handle in OpenCL. This pointer is always
+   * aligned to 256 bytes as in CUDA.
+   *
+   * For given DLTensor, the size of memory required to store the contents of
+   * data is calculated as follows:
+   *
+   * \code{.c}
+   * static inline size_t GetDataSize(const DLTensor* t) {
+   *   size_t size = 1;
+   *   for (tvm_index_t i = 0; i < t->ndim; ++i) {
+   *     size *= t->shape[i];
+   *   }
+   *   size *= (t->dtype.bits * t->dtype.lanes + 7) / 8;
+   *   return size;
+   * }
+   * \endcode
+   */
+  void* data;
+  /*! \brief The device context of the tensor */
+  DLContext ctx;
+  /*! \brief Number of dimensions */
+  int ndim;
+  /*! \brief The data type of the pointer*/
+  DLDataType dtype;
+  /*! \brief The shape of the tensor */
+  int64_t* shape;
+  /*!
+   * \brief strides of the tensor (in number of elements, not bytes)
+   *  can be NULL, indicating tensor is compact and row-majored.
+   */
+  int64_t* strides;
+  /*! \brief The offset in bytes to the beginning pointer to data */
+  uint64_t byte_offset;
+} DLTensor;
+
+/*!
+ * \brief C Tensor object, manage memory of DLTensor. This data structure is
+ *  intended to facilitate the borrowing of DLTensor by another framework. It is
+ *  not meant to transfer the tensor. When the borrowing framework doesn't need
+ *  the tensor, it should call the deleter to notify the host that the resource
+ *  is no longer needed.
+ */
+typedef struct DLManagedTensor {
+  /*! \brief DLTensor which is being memory managed */
+  DLTensor dl_tensor;
+  /*! \brief the context of the original host framework of DLManagedTensor in
+   *   which DLManagedTensor is used in the framework. It can also be NULL.
+   */
+  void * manager_ctx;
+  /*! \brief Destructor signature void (*)(void*) - this should be called
+   *   to destruct manager_ctx which holds the DLManagedTensor. It can be NULL
+   *   if there is no way for the caller to provide a reasonable destructor.
+   *   The destructors deletes the argument self as well.
+   */
+  void (*deleter)(struct DLManagedTensor * self);
+} DLManagedTensor;
+#ifdef __cplusplus
+}  // DLPACK_EXTERN_C
+#endif
+#endif  // DLPACK_DLPACK_H_

--- a/include/ion-bb-dnn/3rdparty/tvm/runtime/c_runtime_api.h
+++ b/include/ion-bb-dnn/3rdparty/tvm/runtime/c_runtime_api.h
@@ -1,0 +1,611 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+/*
+ * \file tvm/runtime/c_runtime_api.h
+ * \brief TVM runtime library.
+ *
+ *  The philosophy of TVM project is to customize the compilation
+ *  stage to generate code that can used by other projects transparently.
+ *  So this is a minimum runtime code gluing, and some limited
+ *  memory management code to enable quick testing.
+ *
+ *  The runtime API is independent from TVM compilation stack and can
+ *  be linked via libtvm_runtime.
+ *
+ *  The common flow is:
+ *   - Use TVMFuncListGlobalNames to get global function name
+ *   - Use TVMFuncCall to call these functions.
+ */
+#ifndef TVM_RUNTIME_C_RUNTIME_API_H_
+#define TVM_RUNTIME_C_RUNTIME_API_H_
+
+// Macros to do weak linking
+#ifdef _MSC_VER
+#define TVM_WEAK __declspec(selectany)
+#else
+#define TVM_WEAK __attribute__((weak))
+#endif
+
+#ifdef __EMSCRIPTEN__
+#include <emscripten/emscripten.h>
+#define TVM_DLL EMSCRIPTEN_KEEPALIVE
+#endif
+
+#ifndef TVM_DLL
+#ifdef _WIN32
+#ifdef TVM_EXPORTS
+#define TVM_DLL __declspec(dllexport)
+#else
+#define TVM_DLL __declspec(dllimport)
+#endif
+#else
+#define TVM_DLL __attribute__((visibility("default")))
+#endif
+#endif
+
+// TVM version
+#define TVM_VERSION "0.8.dev0"
+
+// TVM Runtime is DLPack compatible.
+#include <dlpack/dlpack.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stddef.h>
+#include <stdint.h>
+
+/*! \brief type of array index. */
+typedef int64_t tvm_index_t;
+
+/*! \brief Extension device types in TVM */
+typedef enum {
+  kDLAOCL = 5,
+  kDLSDAccel = 6,
+  kOpenGL = 11,
+  kDLMicroDev = 13,
+  kDLHexagon = 14,
+  kDLWebGPU = 15
+  // AddExtraTVMType which is not in DLPack here
+} TVMDeviceExtType;
+
+/*!
+ * \brief The type code in used and only used in TVM FFI for argument passing.
+ *
+ * DLPack consistency:
+ * 1) kTVMArgInt is compatible with kDLInt
+ * 2) kTVMArgFloat is compatible with kDLFloat
+ * 3) kDLUInt is not in ArgTypeCode, but has a spared slot
+ *
+ * Downstream consistency:
+ * The kDLInt, kDLUInt, kDLFloat are kept consistent with the original ArgType code
+ *
+ * It is only used in argument passing, and should not be confused with
+ * DataType::TypeCode, which is DLPack-compatible.
+ *
+ * \sa tvm::runtime::DataType::TypeCode
+ */
+typedef enum {
+  kTVMArgInt = kDLInt,
+  kTVMArgFloat = kDLFloat,
+  kTVMOpaqueHandle = 3U,
+  kTVMNullptr = 4U,
+  kTVMDataType = 5U,
+  kTVMContext = 6U,
+  kTVMDLTensorHandle = 7U,
+  kTVMObjectHandle = 8U,
+  kTVMModuleHandle = 9U,
+  kTVMPackedFuncHandle = 10U,
+  kTVMStr = 11U,
+  kTVMBytes = 12U,
+  kTVMNDArrayHandle = 13U,
+  kTVMObjectRValueRefArg = 14U,
+  // Extension codes for other frameworks to integrate TVM PackedFunc.
+  // To make sure each framework's id do not conflict, use first and
+  // last sections to mark ranges.
+  // Open an issue at the repo if you need a section of code.
+  kTVMExtBegin = 15U,
+  kTVMNNVMFirst = 16U,
+  kTVMNNVMLast = 20U,
+  // The following section of code is used for non-reserved types.
+  kTVMExtReserveEnd = 64U,
+  kTVMExtEnd = 128U,
+} TVMArgTypeCode;
+
+/*!
+ * \brief The Device information, abstract away common device types.
+ */
+typedef DLContext TVMContext;
+
+/*! \brief the array handle */
+typedef DLTensor* TVMArrayHandle;
+
+/*!
+ * \brief Union type of values
+ *  being passed through API and function calls.
+ */
+typedef union {
+  int64_t v_int64;
+  double v_float64;
+  void* v_handle;
+  const char* v_str;
+  DLDataType v_type;
+  TVMContext v_ctx;
+} TVMValue;
+
+/*!
+ * \brief Byte array type used to pass in byte array
+ *  When kTVMBytes is used as data type.
+ */
+typedef struct {
+  const char* data;
+  size_t size;
+} TVMByteArray;
+
+/*! \brief Handle to TVM runtime modules. */
+typedef void* TVMModuleHandle;
+/*! \brief Handle to packed function handle. */
+typedef void* TVMFunctionHandle;
+/*! \brief Handle to hold return value. */
+typedef void* TVMRetValueHandle;
+/*!
+ * \brief The stream that is specific to device
+ * can be NULL, which indicates the default one.
+ */
+typedef void* TVMStreamHandle;
+/*! \brief Handle to Object. */
+typedef void* TVMObjectHandle;
+
+/*!
+ * \brief Used for implementing C API function.
+ *  Set last error message before return.
+ * \param msg The error message to be set.
+ */
+TVM_DLL void TVMAPISetLastError(const char* msg);
+
+/*!
+ * \brief return str message of the last error
+ *  all function in this file will return 0 when success
+ *  and -1 when an error occurred,
+ *  TVMGetLastError can be called to retrieve the error
+ *
+ *  this function is threadsafe and can be called by different thread
+ *  \return error info
+ */
+TVM_DLL const char* TVMGetLastError(void);
+/*!
+ * \brief Load module from file.
+ * \param file_name The file name to load the module from.
+ * \param format The format of the module.
+ * \param out The result module
+ *
+ * \return 0 when success, -1 when failure happens
+ * \note The resulting module do not contain import relation.
+ *  It can be reconstructed by TVMModImport.
+ */
+TVM_DLL int TVMModLoadFromFile(const char* file_name, const char* format, TVMModuleHandle* out);
+
+/*!
+ * \brief Add dep to mod's dependency.
+ *  This allows functions in this module to use modules.
+ *
+ * \param mod The module handle.
+ * \param dep The dependent module to be imported.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMModImport(TVMModuleHandle mod, TVMModuleHandle dep);
+
+/*!
+ * \brief Get function from the module.
+ * \param mod The module handle.
+ * \param func_name The name of the function.
+ * \param query_imports Whether to query imported modules
+ * \param out The result function, can be NULL if it is not available.
+ * \return 0 when no error is thrown, -1 when failure happens
+ */
+TVM_DLL int TVMModGetFunction(TVMModuleHandle mod, const char* func_name, int query_imports,
+                              TVMFunctionHandle* out);
+
+/*!
+ * \brief Free the Module
+ * \param mod The module to be freed.
+ *
+ * \note This may not free up the module's resources.
+ *  If there is active TVMFunctionHandle uses the module
+ *  Or if this module is imported by another active module.
+ *
+ *  The all functions remains valid until TVMFuncFree is called.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMModFree(TVMModuleHandle mod);
+
+/*!
+ * \brief Free the function when it is no longer needed.
+ * \param func The function handle
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMFuncFree(TVMFunctionHandle func);
+
+/*!
+ * \brief Call a Packed TVM Function.
+ *
+ * \param func node handle of the function.
+ * \param arg_values The arguments
+ * \param type_codes The type codes of the arguments
+ * \param num_args Number of arguments.
+ *
+ * \param ret_val The return value.
+ * \param ret_type_code the type code of return value.
+ *
+ * \return 0 when success, -1 when failure happens
+ * \note TVM calls always exchanges with type bits=64, lanes=1
+ *
+ * \note API calls always exchanges with type bits=64, lanes=1
+ *   If API call returns container handles (e.g. FunctionHandle)
+ *   these handles should be managed by the front-end.
+ *   The front-end need to call free function (e.g. TVMFuncFree)
+ *   to free these handles.
+ */
+TVM_DLL int TVMFuncCall(TVMFunctionHandle func, TVMValue* arg_values, int* type_codes, int num_args,
+                        TVMValue* ret_val, int* ret_type_code);
+
+/*!
+ * \brief Set the return value of TVMPackedCFunc.
+ *
+ *  This function is called by TVMPackedCFunc to set the return value.
+ *  When this function is not called, the function returns null by default.
+ *
+ * \param ret The return value handle, pass by ret in TVMPackedCFunc
+ * \param value The value to be returned.
+ * \param type_code The type of the value to be returned.
+ * \param num_ret Number of return values, for now only 1 is supported.
+ */
+TVM_DLL int TVMCFuncSetReturn(TVMRetValueHandle ret, TVMValue* value, int* type_code, int num_ret);
+
+/*!
+ * \brief Inplace translate callback argument value to return value.
+ *  This is only needed for non-POD arguments.
+ *
+ * \param value The value to be translated.
+ * \param code The type code to be translated.
+ * \note This function will do a shallow copy when necessary.
+ *
+ * \return 0 when success, -1 when failure happens.
+ */
+TVM_DLL int TVMCbArgToReturn(TVMValue* value, int* code);
+
+/*!
+ * \brief C type of packed function.
+ *
+ * \param args The arguments
+ * \param type_codes The type codes of the arguments
+ * \param num_args Number of arguments.
+ * \param ret The return value handle.
+ * \param resource_handle The handle additional resouce handle from fron-end.
+ * \return 0 if success, -1 if failure happens, set error via TVMAPISetLastError.
+ * \sa TVMCFuncSetReturn
+ */
+typedef int (*TVMPackedCFunc)(TVMValue* args, int* type_codes, int num_args, TVMRetValueHandle ret,
+                              void* resource_handle);
+
+/*!
+ * \brief C callback to free the resource handle in C packed function.
+ * \param resource_handle The handle additional resouce handle from fron-end.
+ */
+typedef void (*TVMPackedCFuncFinalizer)(void* resource_handle);
+
+/*!
+ * \brief Signature for extension function declarer.
+ *
+ *  TVM call this function to get the extension functions
+ *  The declarer will call register_func to register function and their name.
+ *
+ * \param register_func_handle The register function
+ * \return 0 if success, -1 if failure happens
+ */
+typedef int (*TVMExtensionFuncDeclarer)(TVMFunctionHandle register_func_handle);
+
+/*!
+ * \brief Wrap a TVMPackedCFunc to become a FunctionHandle.
+ *
+ * The resource_handle will be managed by TVM API, until the function is no longer used.
+ *
+ * \param func The packed C function.
+ * \param resource_handle The resource handle from front-end, can be NULL.
+ * \param fin The finalizer on resource handle when the FunctionHandle get freed, can be NULL
+ * \param out the result function handle.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMFuncCreateFromCFunc(TVMPackedCFunc func, void* resource_handle,
+                                   TVMPackedCFuncFinalizer fin, TVMFunctionHandle* out);
+
+/*!
+ * \brief Register the function to runtime's global table.
+ *
+ * The registered function then can be pulled by the backend by the name.
+ *
+ * \param name The name of the function.
+ * \param f The function to be registered.
+ * \param override Whether allow override already registered function.
+ */
+TVM_DLL int TVMFuncRegisterGlobal(const char* name, TVMFunctionHandle f, int override);
+
+/*!
+ * \brief Get a global function.
+ *
+ * \param name The name of the function.
+ * \param out the result function pointer, NULL if it does not exist.
+ *
+ * \note The function handle of global function is managed by TVM runtime,
+ *  So TVMFuncFree is should not be called when it get deleted.
+ */
+TVM_DLL int TVMFuncGetGlobal(const char* name, TVMFunctionHandle* out);
+
+/*!
+ * \brief List all the globally registered function name
+ * \param out_size The number of functions
+ * \param out_array The array of function names.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMFuncListGlobalNames(int* out_size, const char*** out_array);
+
+/*!
+ * \brief Remove a global function.
+ * \param name The name of the function.
+ */
+TVM_DLL int TVMFuncRemoveGlobal(const char* name);
+
+// Array related apis for quick proptyping
+/*!
+ * \brief Allocate a nd-array's memory,
+ *  including space of shape, of given spec.
+ *
+ * \param shape The shape of the array, the data content will be copied to out
+ * \param ndim The number of dimension of the array.
+ * \param dtype_code The type code of the dtype
+ * \param dtype_bits The number of bits of dtype
+ * \param dtype_lanes The number of lanes in the dtype.
+ * \param device_type The device type of context
+ * \param device_id The device id of context.
+ * \param out The output handle.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMArrayAlloc(const tvm_index_t* shape, int ndim, int dtype_code, int dtype_bits,
+                          int dtype_lanes, int device_type, int device_id, TVMArrayHandle* out);
+
+/*!
+ * \brief Free the TVM Array.
+ * \param handle The array handle to be freed.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMArrayFree(TVMArrayHandle handle);
+
+/*!
+ * \brief Copy array data from CPU byte array.
+ * \param handle The array handle.
+ * \param data the data pointer
+ * \param nbytes The number of bytes to copy.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMArrayCopyFromBytes(TVMArrayHandle handle, void* data, size_t nbytes);
+
+/*!
+ * \brief Copy array data to CPU byte array.
+ * \param handle The array handle.
+ * \param data the data pointer
+ * \param nbytes The number of bytes to copy.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMArrayCopyToBytes(TVMArrayHandle handle, void* data, size_t nbytes);
+
+/*!
+ * \brief Copy the array, both from and to must be valid during the copy.
+ * \param from The array to be copied from.
+ * \param to The target space.
+ * \param stream The stream where the copy happens, can be NULL.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMArrayCopyFromTo(TVMArrayHandle from, TVMArrayHandle to, TVMStreamHandle stream);
+
+/*!
+ * \brief Produce an array from the DLManagedTensor that shares data memory
+ * with the DLManagedTensor.
+ * \param from The source DLManagedTensor.
+ * \param out The output array handle.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMArrayFromDLPack(DLManagedTensor* from, TVMArrayHandle* out);
+
+/*!
+ * \brief Produce a DLMangedTensor from the array that shares data memory with
+ * the array.
+ * \param from The source array.
+ * \param out The DLManagedTensor handle.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMArrayToDLPack(TVMArrayHandle from, DLManagedTensor** out);
+
+/*!
+ * \brief Delete (free) a DLManagedTensor's data.
+ * \param dltensor Pointer to the DLManagedTensor.
+ */
+TVM_DLL void TVMDLManagedTensorCallDeleter(DLManagedTensor* dltensor);
+
+/*!
+ * \brief Create a new runtime stream.
+ *
+ * \param device_type The device type of context
+ * \param device_id The device id of context
+ * \param out The new stream handle
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMStreamCreate(int device_type, int device_id, TVMStreamHandle* out);
+
+/*!
+ * \brief Free a created stream handle.
+ *
+ * \param device_type The device type of context
+ * \param device_id The device id of context
+ * \param stream The stream to be freed
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMStreamFree(int device_type, int device_id, TVMStreamHandle stream);
+
+/*!
+ * \brief Set the runtime stream of current thread to be stream.
+ *  The subsequent calls to the same device_type
+ *  will use the setted stream handle.
+ *  The specific type of stream is runtime device dependent.
+ *
+ * \param device_type The device type of context
+ * \param device_id The device id of context.
+ * \param handle The stream handle.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMSetStream(int device_type, int device_id, TVMStreamHandle handle);
+
+/*!
+ * \brief Wait until all computations on stream completes.
+ *
+ * \param device_type The device type of context
+ * \param device_id The device id of context.
+ * \param stream The stream to be synchronized.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMSynchronize(int device_type, int device_id, TVMStreamHandle stream);
+
+/*!
+ * \brief Synchronize two streams of execution.
+ *
+ * \param device_type The device type of context
+ * \param device_id The device id of context
+ * \param src The source stream to synchronize.
+ * \param dst The destination stream to synchronize.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMStreamStreamSynchronize(int device_type, int device_id, TVMStreamHandle src,
+                                       TVMStreamHandle dst);
+
+/*!
+ * \brief Get the type_index from an object.
+ *
+ * \param obj The object handle.
+ * \param out_tindex the output type index.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMObjectGetTypeIndex(TVMObjectHandle obj, unsigned* out_tindex);
+
+/*!
+ * \brief Convert type key to type index.
+ * \param type_key The key of the type.
+ * \param out_tindex the corresponding type index.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMObjectTypeKey2Index(const char* type_key, unsigned* out_tindex);
+
+/*!
+ * \brief Increase the reference count of an object.
+ *
+ * \param obj The object handle.
+ * \note Internally we increase the reference counter of the object.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMObjectRetain(TVMObjectHandle obj);
+
+/*!
+ * \brief Free the object.
+ *
+ * \param obj The object handle.
+ * \note Internally we decrease the reference counter of the object.
+ *       The object will be freed when every reference to the object are removed.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMObjectFree(TVMObjectHandle obj);
+
+/*!
+ * \brief Free a TVMByteArray returned from TVMFuncCall, and associated memory.
+ * \param arr The TVMByteArray instance.
+ * \return 0 on success, -1 on failure.
+ */
+TVM_DLL int TVMByteArrayFree(TVMByteArray* arr);
+
+/*!
+ * \brief Allocate a data space on device.
+ * \param ctx The device context to perform operation.
+ * \param nbytes The number of bytes in memory.
+ * \param alignment The alignment of the memory.
+ * \param type_hint The type of elements. Only needed by certain backends such
+ *                   as nbytes & alignment are sufficient for most backends.
+ * \param out_data The allocated device pointer.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMDeviceAllocDataSpace(DLContext ctx, size_t nbytes, size_t alignment,
+                                    DLDataType type_hint, void** out_data);
+
+/*!
+ * \brief Allocate a data space on device with special memory scope.
+ * \note The memory could use a special multi-dimensional memory layout.
+ *       That is why we pass shape and dtype instead of raw number of bytes.
+ * \param ctx The device context to perform operation.
+ * \param ndim The number of dimension of the tensor.
+ * \param shape The shape of the tensor.
+ * \param dtype The type of elements.
+ * \param mem_scope The memory scope of the tensor,
+ *        can be nullptr, which indicate the default global DRAM
+ * \param out_data The allocated device pointer.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMDeviceAllocDataSpaceWithScope(DLContext ctx, int ndim, const int64_t* shape,
+                                             DLDataType dtype, const char* mem_scope,
+                                             void** out_data);
+
+/*!
+ * \brief Free a data space on device.
+ * \param ctx The device context to perform operation.
+ * \param ptr The data space.
+ * \return 0 when success, -1 when failure happens
+ */
+TVM_DLL int TVMDeviceFreeDataSpace(TVMContext ctx, void* ptr);
+
+/*!
+ * \brief Copy data from one place to another.
+ * \note This API is designed to support special memory with shape dependent layout.
+ *       We pass in DLTensor* with shape information to support these cases.
+ * \param from The source tensor.
+ * \param to The target tensor.
+ * \param stream Optional stream object.
+ * \return 0 when success, -1 when failure happens.
+ */
+TVM_DLL int TVMDeviceCopyDataFromTo(DLTensor* from, DLTensor* to, TVMStreamHandle stream);
+
+/*!
+ * \brief Check that an object is derived from another.
+ * \param child_type_index The type index of the derived type.
+ * \param parent_type_index The type index of the parent type.
+ * \param is_derived A boolean representing whether this predicate holds.
+ * \return 0 when success, -1 when failure happens.
+ */
+TVM_DLL int TVMObjectDerivedFrom(uint32_t child_type_index, uint32_t parent_type_index,
+                                 int* is_derived);
+
+#ifdef __cplusplus
+}  // TVM_EXTERN_C
+#endif
+#endif  // TVM_RUNTIME_C_RUNTIME_API_H_

--- a/include/ion-bb-dnn/bb.h
+++ b/include/ion-bb-dnn/bb.h
@@ -49,13 +49,16 @@ enum class DNNModelKind : int32_t {
     ssd_mobilenet_v2_coco,
     ssdlite_mobilenet_v2_coco,
     ssdlite_mobiledet_edgetpu_coco,
+    ssdlite_mobiledet_gpu_coco
 };
 
 const std::map<std::string, DNNModelKind> dnn_model_enum_map{
     {"ssd_mobilenet_v1_coco", DNNModelKind::ssd_mobilenet_v1_coco},
     {"ssd_mobilenet_v2_coco", DNNModelKind::ssd_mobilenet_v2_coco},
     {"ssdlite_mobilenet_v2_coco", DNNModelKind::ssdlite_mobilenet_v2_coco},
-    {"ssdlite_mobiledet_edgetpu_coco", DNNModelKind::ssdlite_mobiledet_edgetpu_coco}};
+    {"ssdlite_mobiledet_edgetpu_coco", DNNModelKind::ssdlite_mobiledet_edgetpu_coco},
+    {"ssdlite_mobiledet_gpu_coco", DNNModelKind::ssdlite_mobiledet_gpu_coco},
+};
 
 template<typename X, int32_t D>
 class ObjectDetectionBase : public BuildingBlock<X> {
@@ -122,6 +125,9 @@ public:
             break;
         case DNNModelKind::ssdlite_mobiledet_edgetpu_coco:
             dnn_model_name = "ssdlite_mobiledet_edgetpu_coco";
+            break;
+        case DNNModelKind::ssdlite_mobiledet_gpu_coco:
+            dnn_model_name = "ssdlite_mobiledet_gpu_coco";
             break;
         default:
             std::cerr << "Error: unsupported dnn modles" << std::endl;

--- a/include/ion-bb-dnn/bb.h
+++ b/include/ion-bb-dnn/bb.h
@@ -44,6 +44,19 @@ private:
     Halide::Var c, x, y;
 };
 
+enum class DNNModelKind : int32_t {
+    ssd_mobilenet_v1_coco,
+    ssd_mobilenet_v2_coco,
+    ssdlite_mobilenet_v2_coco,
+    ssdlite_mobiledet_edgetpu_coco,
+};
+
+const std::map<std::string, DNNModelKind> dnn_model_enum_map{
+    {"ssd_mobilenet_v1_coco", DNNModelKind::ssd_mobilenet_v1_coco},
+    {"ssd_mobilenet_v2_coco", DNNModelKind::ssd_mobilenet_v2_coco},
+    {"ssdlite_mobilenet_v2_coco", DNNModelKind::ssdlite_mobilenet_v2_coco},
+    {"ssdlite_mobiledet_edgetpu_coco", DNNModelKind::ssdlite_mobiledet_edgetpu_coco}};
+
 template<typename X, int32_t D>
 class ObjectDetectionBase : public BuildingBlock<X> {
     static_assert(D == 3 || D == 4, "D must be 3 or 4.");
@@ -58,6 +71,9 @@ public:
 
     GeneratorParam<std::string> model_root_url_{"model_base_url", "http://ion-archives.s3-us-west-2.amazonaws.com/models/"};
     GeneratorParam<std::string> cache_root_{"cache_root", "/tmp/"};
+
+    GeneratorParam<DNNModelKind> dnn_model_kind_{"dnn_model_kind", DNNModelKind::ssd_mobilenet_v1_coco, dnn_model_enum_map};
+    GeneratorParam<bool> edgetpu_enable_{"edgetpu_enable", false};
 
     // TODO: Embed model at compilation time
     // GeneratorParam<bool> embed_model{"embed_model", false};
@@ -89,10 +105,59 @@ public:
         dnndk_enable = (this->get_target().has_feature(Target::Feature::DPU));
 #endif
 
+        // Use edgetpu or not
+        const bool edgetpu_enable = edgetpu_enable_;
+
+        // Base model name
+        std::string dnn_model_name;
+        switch (dnn_model_kind_) {
+        case DNNModelKind::ssd_mobilenet_v1_coco:
+            dnn_model_name = "ssd_mobilenet_v1_coco";
+            break;
+        case DNNModelKind::ssd_mobilenet_v2_coco:
+            dnn_model_name = "ssd_mobilenet_v2_coco";
+            break;
+        case DNNModelKind::ssdlite_mobilenet_v2_coco:
+            dnn_model_name = "ssdlite_mobilenet_v2_coco";
+            break;
+        case DNNModelKind::ssdlite_mobiledet_edgetpu_coco:
+            dnn_model_name = "ssdlite_mobiledet_edgetpu_coco";
+            break;
+        default:
+            std::cerr << "Error: unsupported dnn modles" << std::endl;
+            exit(1);
+        }
+
+        Halide::Buffer<uint8_t> dnn_model_name_buf(dnn_model_name.size() + 1);
+        dnn_model_name_buf.fill(0);
+        std::memcpy(dnn_model_name_buf.data(), dnn_model_name.c_str(), dnn_model_name.size());
+
+        // Target arch type
+        // NOTE shuld we support 32-bits archs?
+        std::string arch_type;
+        const auto &arch = this->get_target().arch;
+        if (arch == Halide::Target::Arch::X86) {
+            arch_type = "x86_64";
+        } else if (arch == Halide::Target::Arch::ARM) {
+            arch_type = "aarch64";
+        }
+        Halide::Buffer<uint8_t> target_arch_buf(arch_type.size() + 1);
+        target_arch_buf.fill(0);
+        std::memcpy(target_arch_buf.data(), arch_type.c_str(), arch_type.size());
+
         input = Func{static_cast<std::string>(gc_prefix) + "in"};
         input(_) = input_(_);
 
-        std::vector<ExternFuncArgument> params{input, session_id_buf, model_root_url_buf, cache_path_buf, cuda_enable, dnndk_enable};
+        std::vector<ExternFuncArgument> params{
+            input,
+            session_id_buf,
+            model_root_url_buf,
+            cache_path_buf,
+            cuda_enable,
+            dnndk_enable,
+            edgetpu_enable,
+            dnn_model_name_buf,
+            target_arch_buf};
         Func object_detection(static_cast<std::string>(gc_prefix) + "object_detection");
         object_detection.define_extern("ion_bb_dnn_generic_object_detection", params, Float(32), D);
         object_detection.compute_root();

--- a/include/ion-bb-dnn/config.cmake
+++ b/include/ion-bb-dnn/config.cmake
@@ -4,22 +4,6 @@ if (UNIX)
     add_compile_options(-Wno-format-security)
 endif()
 
-#
-# tvm
-#
-if(NOT WITH_TVM STREQUAL "OFF")
-  message(STATUS "will use libtvm_runtime.so")
-
-  # confirm CMake can find the libtvm_runtime.so & set rpath if required
-  if (WITH_TVM STREQUAL "ON")
-      find_library(TVM_RUNTIME_LIB libtvm_runtime.so REQUIRED)
-  else()
-      find_library(TVM_RUNTIME_LIB NAMES libtvm_runtime.so PATHS ${WITH_TVM} REQUIRED)
-      get_filename_component(RPATH_DIR ${TVM_RUNTIME_LIB} DIRECTORY)
-      set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath ${RPATH_DIR}")
-  endif()
-endif()
-
 set(INCLUDE_DIRS
     ${CMAKE_SOURCE_DIR}/include/ion-bb-dnn/3rdparty
     ${OpenCV_INCLUDE_DIRS})

--- a/include/ion-bb-dnn/config.cmake
+++ b/include/ion-bb-dnn/config.cmake
@@ -4,7 +4,24 @@ if (UNIX)
     add_compile_options(-Wno-format-security)
 endif()
 
+#
+# tvm
+#
+if(NOT WITH_TVM STREQUAL "OFF")
+  message(STATUS "will use libtvm_runtime.so")
+
+  # confirm CMake can find the libtvm_runtime.so & set rpath if required
+  if (WITH_TVM STREQUAL "ON")
+      find_library(TVM_RUNTIME_LIB libtvm_runtime.so REQUIRED)
+  else()
+      find_library(TVM_RUNTIME_LIB NAMES libtvm_runtime.so PATHS ${WITH_TVM} REQUIRED)
+      get_filename_component(RPATH_DIR ${TVM_RUNTIME_LIB} DIRECTORY)
+      set(CMAKE_EXE_LINKER_FLAGS "-Wl,-rpath ${RPATH_DIR}")
+  endif()
+endif()
+
 set(INCLUDE_DIRS
+    ${CMAKE_SOURCE_DIR}/include/ion-bb-dnn/3rdparty
     ${OpenCV_INCLUDE_DIRS})
 
 set(LINK_DIRS

--- a/include/ion-bb-dnn/rt_tvm.h
+++ b/include/ion-bb-dnn/rt_tvm.h
@@ -465,8 +465,15 @@ int object_detection_tvm(halide_buffer_t *in,
         TVMModuleHandle M = mgr.init_runtime_module();
 
         // Resize for tensor input data
-        const auto internal_height = 300;
-        const auto internal_width = 300;
+        int internal_height = 300;
+        int internal_width = 300;
+        // For ssdlite_mobiledet_* and ssd_mobilenet_v3_* models, we should use 320 * 320
+        // Currently, we only support below two models
+        if (dnn_model_name == "ssdlite_mobiledet_edgetpu_coco" ||
+            dnn_model_name == "ssdlite_mobiledet_gpu_coco") {
+            internal_height = 320;
+            internal_width = 320;
+        }
         cv::Mat resized(internal_height, internal_width, CV_32FC3);
         cv::resize(in_, resized, resized.size());
 

--- a/include/ion-bb-dnn/rt_tvm.h
+++ b/include/ion-bb-dnn/rt_tvm.h
@@ -1,0 +1,513 @@
+#ifndef ION_BB_DNN_RT_TVM_H
+#define ION_BB_DNN_RT_TVM_H
+
+#include <string>
+#include <sys/utsname.h>
+
+#include <dlpack/dlpack.h>
+#include <tvm/runtime/c_runtime_api.h>
+
+#include <HalideBuffer.h>
+
+namespace ion {
+namespace bb {
+namespace dnn {
+
+namespace {
+
+// Function ptrs for tvm c api functions
+#define DECL_TVM_FUNC(NAME) decltype(&::NAME) NAME;
+DECL_TVM_FUNC(TVMFuncGetGlobal);
+DECL_TVM_FUNC(TVMFuncCall);
+DECL_TVM_FUNC(TVMGetLastError);
+DECL_TVM_FUNC(TVMModLoadFromFile);
+DECL_TVM_FUNC(TVMModGetFunction);
+DECL_TVM_FUNC(TVMArrayAlloc);
+DECL_TVM_FUNC(TVMArrayCopyFromBytes);
+
+// dlsym for tvm functions
+#define RESOLVE_TVM_FUNC(NAME)                                    \
+    ion::bb::dnn::NAME = dm.get_symbol<decltype(&::NAME)>(#NAME); \
+    if (ion::bb::dnn::NAME == nullptr) {                          \
+        throw std::runtime_error(                                 \
+            #NAME " is unavailable on your tvm runtime");         \
+    }
+
+bool tvm_runtime_init() {
+    // should locate libtvm_runtime.so under searchable directory like /usr/lib
+    static ion::bb::dnn::DynamicModule dm("tvm_runtime");
+    if (!dm.is_available()) {
+        return false;
+    }
+
+    RESOLVE_TVM_FUNC(TVMFuncGetGlobal);
+    RESOLVE_TVM_FUNC(TVMGetLastError);
+    RESOLVE_TVM_FUNC(TVMFuncCall);
+    RESOLVE_TVM_FUNC(TVMModLoadFromFile);
+    RESOLVE_TVM_FUNC(TVMModGetFunction);
+    RESOLVE_TVM_FUNC(TVMArrayAlloc);
+    RESOLVE_TVM_FUNC(TVMArrayCopyFromBytes);
+    return true;
+}
+#undef DECL_TVM_FUNC
+#undef RESOLVE_TVM_FUNC
+
+std::string load_file(const std::string &path, bool binary = false) {
+    const auto mode = binary ? std::ios::binary : std::ios::in;
+    std::ifstream ifs(path, mode);
+    if (ifs.fail()) {
+        throw std::runtime_error("could not open file");
+    }
+
+    std::string data((std::istreambuf_iterator<char>(ifs)),
+                     std::istreambuf_iterator<char>());
+
+    return data;
+}
+
+template<typename T>
+T ndarray_at(TVMArrayHandle array,
+             const std::vector<int64_t> &indices) {
+
+    assert(array->ndim == indices.size());
+    // TODO: Support strides.
+    assert(array->strides == nullptr);
+    // TODO: Support offset.
+    assert(array->byte_offset == 0U);
+
+    int64_t *shape = array->shape;
+    int64_t index = 0;
+    for (auto dim = decltype(indices.size())(0); dim < indices.size(); ++dim) {
+        int64_t stride = 1;
+        for (size_t i = dim + 1; i < array->ndim; ++i) {
+            stride *= shape[i];
+        }
+
+        index += indices[dim] * stride;
+    };
+
+    return reinterpret_cast<T *>(array->data)[index];
+}
+
+std::vector<DetectionBox> postprocess(TVMArrayHandle nums,
+                                      TVMArrayHandle boxes,
+                                      TVMArrayHandle labels,
+                                      TVMArrayHandle scores) {
+    // Assume single batch.
+    const int64_t batch = 0;
+    int32_t num = -1;
+    auto dtype_code = nums->dtype.code;
+    if (dtype_code == kDLInt) {
+        num = (int32_t)ndarray_at<int32_t>(nums, {0});
+    } else if (dtype_code == kDLFloat) {
+        num = (int32_t)ndarray_at<float>(nums, {0});
+    }
+
+    if (num < 0) {
+        std::cerr << "Error: failed to get num" << std::endl;
+    }
+
+    std::vector<DetectionBox> valid_boxes;
+    for (auto i = decltype(num)(0); i < num; ++i) {
+        // Added offset of background.
+        const auto class_id =
+            static_cast<int32_t>(ndarray_at<float>(labels, {batch, i})) + 1;
+        const auto confidence = ndarray_at<float>(scores, {batch, i});
+
+        // Boxes is formatted as [y1, x1, y2, x2] nomalized [0, 1)
+        const auto x1 = ndarray_at<float>(boxes, {batch, i, 1});
+        const auto y1 = ndarray_at<float>(boxes, {batch, i, 0});
+        const auto x2 = ndarray_at<float>(boxes, {batch, i, 3});
+        const auto y2 = ndarray_at<float>(boxes, {batch, i, 2});
+
+        valid_boxes.emplace_back(
+            DetectionBox{class_id, confidence, x1, x2, y1, y2});
+    }
+
+    return valid_boxes;
+}
+
+}  // namespace
+
+class TVMSessionManager {
+private:
+    bool init_configs_ = false;
+    DLContext dlctx_;
+    std::string model_base_url_ = "";
+    std::string model_cache_dir_ = "";
+    bool use_cuda_ = false;
+    bool use_edgetpu_ = false;
+    std::string dnn_model_name_;
+    std::string target_arch_;
+
+    std::unordered_map<std::string, TVMModuleHandle> modules_;
+    TVMFunctionHandle runtime_creator_;
+
+    bool is_available_tvm_;
+    TVMSessionManager()
+        : is_available_tvm_(false) {
+        if (!tvm_runtime_init()) {
+            std::cerr << "Log: could not init the tvm runtime" << std::endl;
+            return;
+        }
+        is_available_tvm_ = true;
+    }
+
+    void init_runtime_creator() {
+
+        if (use_edgetpu_) {
+            TVMFuncGetGlobal("tvm.edgetpu_runtime.create", &runtime_creator_);
+        } else {
+            TVMFuncGetGlobal("tvm.graph_runtime.create", &runtime_creator_);
+        }
+
+        if (!runtime_creator_) {
+            std::cerr << "Error: failed to get any runtime creator from tvm" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+
+        return;
+    }
+
+    std::string resolve_model_filename() {
+        std::string model_file = dnn_model_name_;
+
+        if (use_edgetpu_) {
+            model_file += "_int8_edgetpu.tflite";
+        } else {
+            model_file += "_" + target_arch_;
+            if (use_cuda_) {
+                model_file += "_cuda";
+            }
+            model_file += ".tar";
+        }
+
+        return model_file;
+    }
+
+    bool have_file_cache(const std::string &filename) {
+        std::ifstream ifs(model_cache_dir_ + filename, std::ios::binary);
+        return ifs.is_open();
+    }
+
+    bool download_model_file(const std::string &model_url, const std::string &model_file) {
+
+        std::string host_name;
+        std::string path_name;
+        std::tie(host_name, path_name) = parse_url(model_url);
+        if (host_name.empty() || path_name.empty()) {
+            std::cerr << "Error: invalid model URL : " << model_url << std::endl;
+            return false;
+        }
+
+        httplib::Client cli(host_name.c_str());
+        cli.set_follow_location(true);
+        auto res = cli.Get(path_name.c_str());
+        if (!res || res->status != 200) {
+            std::cerr << "Error: failed to download model (cli.Get): " << model_url << std::endl;
+            return false;
+        }
+
+        std::shared_ptr<std::vector<uint8_t>> model_data;
+        model_data = std::shared_ptr<std::vector<uint8_t>>(new std::vector<uint8_t>(res->body.size()));
+        std::memcpy(model_data->data(), res->body.c_str(), res->body.size());
+        std::ofstream ofs(model_cache_dir_ + model_file, std::ios::binary);
+        if (!ofs) {
+            std::cerr << "Error: failed to open a cache entry : " << model_cache_dir_ + model_file << std::endl;
+            return false;
+        }
+        ofs.write(reinterpret_cast<const char *>(model_data->data()), model_data->size());
+
+        return true;
+    }
+
+    TVMModuleHandle create_runtime_module(const std::string &model_filename) {
+        TVMModuleHandle M;
+
+        if (use_edgetpu_) {
+            const auto tflite_model_bytes = load_file(model_cache_dir_ + model_filename, true);
+            TVMByteArray model_bytearray{tflite_model_bytes.c_str(), tflite_model_bytes.length()};
+            TVMValue args[2];
+            args[0].v_handle = &model_bytearray;
+            args[1].v_ctx = dlctx_;
+
+            int arg_types[2];
+            arg_types[0] = kTVMBytes;
+            arg_types[1] = kTVMContext;
+
+            TVMValue ret;
+            int ret_type;
+            if (TVMFuncCall(runtime_creator_, &args[0], &arg_types[0], 2, &ret, &ret_type) < 0) {
+                std::cerr << "Error: failed to execute runtime_creator_ for tflite(edgetpu)" << std::endl;
+                std::cerr << TVMGetLastError() << std::endl;
+                exit(1);
+            }
+            M = ret.v_handle;
+        } else {
+            // TODO a new graph API is comming in the next tvm release
+            // Using mod.json, mod.so, and mod.params is depricated.
+            // We can simply use one shared library for exporiting and loading a tvm::runtime::Module insted
+            std::string extract_cmd = "tar xf " + model_cache_dir_ + model_filename + " -C " + model_cache_dir_;
+            std::system(extract_cmd.c_str());
+
+            const auto json_data = load_file(model_cache_dir_ + "mod.json");
+            std::string model_file_path = model_cache_dir_ + "mod.so";
+            TVMModuleHandle mod;
+            if (TVMModLoadFromFile(model_file_path.c_str(), "", &mod) < 0) {
+                std::cerr << "Error: failed to load model file" << std::endl;
+                exit(1);
+            }
+
+            TVMValue args[4];
+            args[0].v_str = json_data.c_str();
+            args[1].v_handle = mod;
+            args[2].v_int64 = static_cast<int>(dlctx_.device_type);
+            args[3].v_int64 = dlctx_.device_id;
+
+            int arg_types[4];
+            arg_types[0] = kTVMStr;
+            arg_types[1] = kTVMModuleHandle;
+            arg_types[2] = kTVMArgInt;
+            arg_types[3] = kTVMArgInt;
+
+            TVMValue ret;
+            int ret_type;
+            if (TVMFuncCall(runtime_creator_, &args[0], &arg_types[0], 4, &ret, &ret_type) < 0) {
+                std::cerr << "Error: failed to execute runtime_creator_" << std::endl;
+                std::cerr << TVMGetLastError() << std::endl;
+                exit(1);
+            }
+            M = ret.v_handle;
+
+            const auto params_data = load_file(model_cache_dir_ + "mod.params", true);
+            TVMByteArray params_bytearray{params_data.c_str(), params_data.length()};
+            TVMFunctionHandle load_params;
+            TVMModGetFunction(M, "load_params", false, &load_params);
+
+            TVMValue arg2;
+            arg2.v_handle = &params_bytearray;
+            int type_code2 = kTVMBytes;
+            if (TVMFuncCall(load_params, &arg2, &type_code2, 1, &ret, &ret_type) < 0) {
+                std::cerr << "Error: failed to execute load_params" << std::endl;
+                std::cerr << TVMGetLastError() << std::endl;
+                exit(1);
+            }
+        }
+
+        return M;
+    }
+
+public:
+    static TVMSessionManager &get_instance() {
+        static TVMSessionManager instance;
+        return instance;
+    }
+
+    bool is_tvm_available() {
+        return is_available_tvm_;
+    }
+
+    void setup_config(const DLContext &ctx,
+                      const std::string &model_root_url,
+                      const std::string &cache_root,
+                      bool cuda_enable,
+                      bool edgetpu_enable,
+                      const std::string &dnn_model_name,
+                      const std::string &target_arch) {
+        dlctx_ = ctx;
+        model_base_url_ = model_root_url;
+        model_cache_dir_ = cache_root;
+        use_cuda_ = cuda_enable;
+        use_edgetpu_ = edgetpu_enable;
+        dnn_model_name_ = dnn_model_name;
+        target_arch_ = target_arch;
+        init_configs_ = true;
+    }
+
+    TVMModuleHandle init_runtime_module() {
+
+        if (!init_configs_) {
+            std::cerr << "Error: setup_config() should be called before init_runtime_module()" << std::endl;
+            exit(1);
+        }
+
+        init_runtime_creator();
+
+        std::string model_filename = resolve_model_filename();
+        if (model_filename == "") {
+            std::cerr << "Error: failed to resolve the model filename" << std::endl;
+            exit(1);
+        }
+
+        // Check the session manager has already cached the runtime module for this model.
+        std::string model_url = model_base_url_ + "tvm/" + dnn_model_name_ + "/" + model_filename;
+        if (modules_.count(model_url)) {
+            return modules_[model_url];
+        }
+
+        if (!have_file_cache(model_filename)) {
+            if (!download_model_file(model_url, model_filename)) {
+                std::cerr << "Failed to download a model file from " << model_url << std::endl;
+                exit(1);
+            }
+        }
+
+        TVMModuleHandle M = create_runtime_module(model_filename);
+        modules_[model_url] = M;
+        return modules_[model_url];
+    }
+
+    void set_input(const TVMModuleHandle M, const TVMArrayHandle data) {
+        TVMFunctionHandle set_input;
+        TVMModGetFunction(M, "set_input", false, &set_input);
+
+        if (!set_input) {
+            std::cerr << "Error: failed to get a set_input function" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+
+        TVMValue args[2];
+        int arg_types[2];
+        std::string input_name = "normalized_input_image_tensor";
+        if (use_edgetpu_) {
+            args[0].v_int64 = 0;
+            arg_types[0] = kTVMArgInt;
+        } else {
+            args[0].v_str = input_name.c_str();
+            arg_types[0] = kTVMStr;
+        }
+        args[1].v_handle = data;
+        arg_types[1] = kTVMNDArrayHandle;
+        TVMValue ret;
+        int ret_code;
+        if (TVMFuncCall(set_input, &args[0], &arg_types[0], 2, &ret, &ret_code) < 0) {
+            std::cerr << "Error: failed to call set_input" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+    }
+
+    void run_inference(TVMModuleHandle M) {
+        TVMFunctionHandle inference;
+
+        if (use_edgetpu_) {
+            TVMModGetFunction(M, "invoke", false, &inference);
+        } else {
+            TVMModGetFunction(M, "run", false, &inference);
+        }
+
+        if (!inference) {
+            std::cerr << "Error: failed to get a inference function" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+
+        TVMValue ret;
+        int ret_code;
+        if (TVMFuncCall(inference, nullptr, nullptr, 0, &ret, &ret_code) < 0) {
+            std::cerr << "Error: failed to call inference" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+    }
+
+    TVMArrayHandle get_output(TVMModuleHandle M, int index) {
+        TVMFunctionHandle get_output;
+
+        TVMModGetFunction(M, "get_output", false, &get_output);
+
+        TVMValue arg;
+        arg.v_int64 = index;
+        int arg_type = kTVMArgInt;
+
+        TVMValue ret;
+        int ret_code;
+        if (TVMFuncCall(get_output, &arg, &arg_type, 1, &ret, &ret_code) < 0) {
+            std::cerr << "Error: failed to call inference" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+
+        return reinterpret_cast<TVMArrayHandle>(ret.v_handle);
+    }
+};
+
+bool is_tvm_available() {
+    return TVMSessionManager::get_instance().is_tvm_available();
+}
+
+int object_detection_tvm(halide_buffer_t *in,
+                         const std::string &model_root_url,
+                         const std::string &cache_root,
+                         bool cuda_enable,
+                         bool edgetpu_enable,
+                         const std::string &dnn_model_name,
+                         const std::string &target_arch,
+                         halide_buffer_t *out) {
+    const int channel = 3;
+    const int width = in->dim[1].extent;
+    const int height = in->dim[2].extent;
+
+    size_t input_size = 3 * width * height * sizeof(float);
+    int num_images = in->dimensions == 3 ? 1 : in->dim[3].extent;
+
+    for (int i = 0; i < num_images; ++i) {
+        // Open image
+        int offset = input_size * i;
+        cv::Mat in_(height, width, CV_32FC3, in->host + offset);
+
+        // Init tvm::runtime::Module
+        auto &mgr = TVMSessionManager::get_instance();
+        const DLContext ctx{kDLCPU, 1};
+        mgr.setup_config(ctx, model_root_url, cache_root, cuda_enable, edgetpu_enable, dnn_model_name, target_arch);
+        TVMModuleHandle M = mgr.init_runtime_module();
+
+        // Resize for tensor input data
+        const auto internal_height = 300;
+        const auto internal_width = 300;
+        cv::Mat resized(internal_height, internal_width, CV_32FC3);
+        cv::resize(in_, resized, resized.size());
+
+        // Convert cv::Mat into tvm::runtime::NDArray
+        TVMArrayHandle tensor_input_data;
+        int64_t shape[4] = {1, internal_width, internal_height, 3};
+        if (TVMArrayAlloc(shape, 4, kDLFloat, 32, 1, ctx.device_type, ctx.device_id, &tensor_input_data) < 0) {
+            std::cerr << "Error: failed to allocate tvm array" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+
+        if (TVMArrayCopyFromBytes(tensor_input_data, resized.ptr(), resized.total() * resized.elemSize()) < 0) {
+            std::cerr << "Error: failed to copy from cv::Mat" << std::endl;
+            std::cerr << TVMGetLastError() << std::endl;
+            exit(1);
+        }
+
+        // SetInput
+        mgr.set_input(M, tensor_input_data);
+
+        // Run inference
+        mgr.run_inference(M);
+
+        // GetOutput
+        TVMArrayHandle boxes = mgr.get_output(M, 0);
+        TVMArrayHandle labels = mgr.get_output(M, 1);
+        TVMArrayHandle scores = mgr.get_output(M, 2);
+        TVMArrayHandle num = mgr.get_output(M, 3);
+        const auto valid_boxes = postprocess(num, boxes, labels, scores);
+
+        cv::Mat out_(height, width, CV_32FC3, out->host + offset);
+        in_.copyTo(out_);
+        coco_render_boxes(out_, valid_boxes, width, height);
+    }
+
+    return 0;
+}
+
+}  // namespace dnn
+}  // namespace bb
+}  // namespace ion
+
+#endif  // ION_BB_DNN_RT_TVM_H

--- a/include/ion-bb-dnn/thirdparty_notice.txt
+++ b/include/ion-bb-dnn/thirdparty_notice.txt
@@ -132,3 +132,39 @@ AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
 LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
+
+----
+
+TVM
+
+Copyright (c) 2017 Contributors Licensed under an Apache-2.0 license.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+----
+
+DLPack
+
+Copyright 2017 by Contributors
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+   http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
@iitaku 
ion-bb-dnn において tvm runtime に対応する変更です．

https://gitlab.fixstars.com/ion/ion-kit/-/issues/18#note_459240

のフィードバックに対応したバージョンになります．
フィードバックになかった変更点としては，tvm 用のデータの型情報をとるために `include/ion-bb-dnn/3rdparty` 下に tvm & dlpack (tvm が内部で使っている 3rdparty ヘッダ）のヘッダファイルをおいてあります．
それにあわせて `include/ion-bb-dnn/thirdparty_notice.txt` も変更してあります．

また，もともと TVM 用の CMAKE のオプションとして `WITH_TVM` がありました．
使い方は，`-DWITH_TVM[ON || OFF || /path/to/libtvm_runtime.so]` というように，libtvm_runtime.so へのパスを指定して，必要なら `-Wl,-rpath` を設定していましたが，これだと結局ビルド時に libtvm_runtime.so が必要なるので削除してあります．

なので，slack でデバイス側の設定コマンドとして
```
$ git clone --recursive https://gitlab.fixstars.com/arachne/arachne.git
$ cd arachne
$ ./deploy/scripts/install/install_jetson.sh
```

を共有しましたが，追加で

```
$ sudo ln -s /path/to/arachne/3rdparty/tvm/build/libtvm_runtime.so /usr/lib/.
```

などのデフォルトのライブラリサーチパス上に libtvm_runtime.so を配置する必要があります．

追加で必要な対応がありましたら連絡お願いします．