### PR TITLE
asked to add ION_KIT_PATH to load dll file for WIndows Users

### DIFF
--- a/python/ionpy/native.py
+++ b/python/ionpy/native.py
@@ -4,6 +4,11 @@ import os
 
 if os.name == 'nt':
     ion_core_module = 'ion-core.dll'
+    try:
+        BIN_DIR = os.environ['ION_KIT_PATH']
+    except KeyError:
+        print('To load ' + ion_core_module + ', please set ION_KIT_PATH=<ion-kit-root-directory>')
+    ion_core_module = os.path.join(BIN_PATH, 'bin', ion_core_module)
 elif os.name == 'posix':
     ion_core_module = 'libion-core.so'
 


### PR DESCRIPTION
Windows user can use ionpy by setting ION_KIT_PATH