### PR TITLE
Feature/remove env val ion kit path

### DIFF
--- a/cmake/ImportIonBB.cmake
+++ b/cmake/ImportIonBB.cmake
@@ -75,5 +75,10 @@ macro(ion_import_building_block)
             PUBLIC -fno-rtti  # For Halide::Generator
             PUBLIC -rdynamic) # For JIT compiling
     endif()
-    install(TARGETS ion-bb DESTINATION lib)
+    if (UNIX)
+        install(TARGETS ion-bb DESTINATION lib)
+    else()
+        install(FILES ${CMAKE_BINARY_DIR}/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>/ion-bb.dll DESTINATION bin)
+        install(FILES ${CMAKE_BINARY_DIR}/$<$<CONFIG:Release>:Release>$<$<CONFIG:Debug>:Debug>/ion-bb.lib DESTINATION lib)
+    endif()
 endmacro()

--- a/python/ionpy/Builder.py
+++ b/python/ionpy/Builder.py
@@ -49,8 +49,6 @@ class Builder:
 
     def with_bb_module(self, path: str) -> 'Builder':
         if os.name == 'nt':
-            print(path)
-            print(find_library(path))
             ret = ion_builder_with_bb_module(self.obj, str(find_library(path)).encode())
         else:
             ret = ion_builder_with_bb_module(self.obj, path.encode())

--- a/python/ionpy/Builder.py
+++ b/python/ionpy/Builder.py
@@ -1,5 +1,7 @@
 import ctypes
 from typing import Optional
+from ctypes.util import find_library
+import os
 
 from .native import (
     c_ion_builder_t,
@@ -46,7 +48,12 @@ class Builder:
         return self
 
     def with_bb_module(self, path: str) -> 'Builder':
-        ret = ion_builder_with_bb_module(self.obj, path.encode())
+        if os.name == 'nt':
+            print(path)
+            print(find_library(path))
+            ret = ion_builder_with_bb_module(self.obj, str(find_library(path)).encode())
+        else:
+            ret = ion_builder_with_bb_module(self.obj, path.encode())
         if ret != 0:
             raise Exception('Invalid operation')
 

--- a/python/ionpy/native.py
+++ b/python/ionpy/native.py
@@ -4,15 +4,11 @@ import os
 
 if os.name == 'nt':
     ion_core_module = 'ion-core.dll'
-    try:
-        BIN_PATH = os.environ['ION_KIT_PATH']
-    except KeyError:
-        print('To load ' + ion_core_module + ', please set ION_KIT_PATH=<ion-kit-root-directory>')
-    ion_core_module = os.path.join(BIN_PATH, 'bin', ion_core_module)
 elif os.name == 'posix':
     ion_core_module = 'libion-core.so'
 
 # libion-core.so must be in a directory listed in $LD_LIBRARY_PATH.
+# ion-core.dll must be in a directory listed in %PATH%.
 ion_core = ctypes.cdll.LoadLibrary(ion_core_module)
 
 class c_ion_type_t(ctypes.Structure):

--- a/python/ionpy/native.py
+++ b/python/ionpy/native.py
@@ -1,9 +1,10 @@
 import ctypes
+from ctypes.util import find_library
 
 import os
 
 if os.name == 'nt':
-    ion_core_module = 'ion-core.dll'
+    ion_core_module = find_library('ion-core.dll')
 elif os.name == 'posix':
     ion_core_module = 'libion-core.so'
 


### PR DESCRIPTION
1. get rid of `ION_KIT_PATH` and look for `ion-core.dll` from `PATH` for Windows
2. install `ion-bb.dll` under `bin` instead of `lib` directory