### PR TITLE
Feature/frame buffer mode

### DIFF
--- a/example/u3v_camera2_opencv/u3v_camera2_opencv.cc
+++ b/example/u3v_camera2_opencv/u3v_camera2_opencv.cc
@@ -65,7 +65,8 @@ int main(int argc, char *argv[])
       Param{"pixel_format_ptr", "Mono12"},
       Param{"frame_sync", "true"},
       Param{"gain_key", FEATURE_GAIN_KEY},
-      Param{"exposure_key", FEATURE_EXPOSURE_KEY}
+      Param{"exposure_key", FEATURE_EXPOSURE_KEY},
+      Param{"realtime_diaplay_mode", "true"}
     );
 
   // Define output ports and pass each object from Node instance.

--- a/example/u3v_camera2_opencv/u3v_camera2_opencv.py
+++ b/example/u3v_camera2_opencv/u3v_camera2_opencv.py
@@ -44,12 +44,13 @@ if __name__ == "__main__":
     frame_sync = Param('frame_sync', 'true')
     gain_key = Param('gain_key', feature_gain_key)
     exposure_key = Param('exposure_key', feature_exposure_key)
+    realtime_diaplay_mode = Param('realtime_diaplay_mode', 'true')
 
 
     #    Add node and connect the input port to the node instance
     node = builder.add('image_io_u3v_camera2_u16x2')\
         .set_port([dispose_p, gain0_p, gain1_p, exposure0_p, exposure1_p, ])\
-        .set_param([pixel_format_ptr, frame_sync, gain_key, exposure_key, ])
+        .set_param([pixel_format_ptr, frame_sync, gain_key, exposure_key, realtime_diaplay_mode, ])
 
 
     # Define Output Port

--- a/include/ion-bb-image-io/bb.h
+++ b/include/ion-bb-image-io/bb.h
@@ -557,7 +557,8 @@ public:
     GeneratorParam<std::string> pixel_format_ptr{"pixel_format_ptr", "RGB8"};
     GeneratorParam<std::string> gain_key_ptr{"gain_key", "Gain"};
     GeneratorParam<std::string> exposure_key_ptr{"exposure_key", "Exposure"};
-
+    GeneratorParam<bool> frame_buffer_mode{"frame_buffer_mode", true};
+    
     GeneratorInput<bool> dispose{ "dispose" };
     GeneratorInput<int32_t> gain0{ "gain0" };
     GeneratorInput<int32_t> exposure0{ "exposure0" };
@@ -584,7 +585,7 @@ public:
         std::memcpy(exposure_key_buf.data(), exposure_key.c_str(), exposure_key.size());
 
         std::vector<ExternFuncArgument> params{
-            static_cast<bool>(frame_sync),
+            static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode),
             gain0, exposure0, pixel_format_buf,
             gain_key_buf, exposure_key_buf
          };
@@ -599,7 +600,7 @@ public:
         std::memcpy(pixel_format_buf_cpy.data(), pixel_format.c_str(), pixel_format.size());
 
         Func camera1_frame_count;
-        camera1_frame_count.define_extern("ion_bb_image_io_u3v_camera1_frame_count", { camera1, dispose, 1, static_cast<bool>(frame_sync), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
+        camera1_frame_count.define_extern("ion_bb_image_io_u3v_camera1_frame_count", { camera1, dispose, 1, static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
         camera1_frame_count.compute_root();
         frame_count(_) = camera1_frame_count(_);
     }
@@ -616,6 +617,7 @@ public:
     GeneratorParam<std::string> pixel_format_ptr{"pixel_format_ptr", "RGB8"};
     GeneratorParam<std::string> gain_key_ptr{"gain_key", "Gain"};
     GeneratorParam<std::string> exposure_key_ptr{"exposure_key", "Exposure"};
+    GeneratorParam<bool> frame_buffer_mode{"frame_buffer_mode", true};
 
     GeneratorInput<bool> dispose{ "dispose" };
     GeneratorInput<int32_t> gain0{ "gain0" };
@@ -646,7 +648,7 @@ public:
         std::memcpy(exposure_key_buf.data(), exposure_key.c_str(), exposure_key.size());
 
         std::vector<ExternFuncArgument> params{
-            static_cast<bool>(frame_sync),
+            static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode),
             gain0, gain1, exposure0, exposure1, pixel_format_buf,
             gain_key_buf, exposure_key_buf
          };
@@ -662,7 +664,7 @@ public:
         std::memcpy(pixel_format_buf_cpy.data(), pixel_format.c_str(), pixel_format.size());
 
         Func camera2_frame_count;
-        camera2_frame_count.define_extern("ion_bb_image_io_u3v_camera2_frame_count", { camera2, dispose, 2, static_cast<bool>(frame_sync), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
+        camera2_frame_count.define_extern("ion_bb_image_io_u3v_camera2_frame_count", { camera2, dispose, 2, static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
         camera2_frame_count.compute_root();
         frame_count(_) = camera2_frame_count(_);
     }

--- a/include/ion-bb-image-io/bb.h
+++ b/include/ion-bb-image-io/bb.h
@@ -557,7 +557,7 @@ public:
     GeneratorParam<std::string> pixel_format_ptr{"pixel_format_ptr", "RGB8"};
     GeneratorParam<std::string> gain_key_ptr{"gain_key", "Gain"};
     GeneratorParam<std::string> exposure_key_ptr{"exposure_key", "Exposure"};
-    GeneratorParam<bool> frame_buffer_mode{"frame_buffer_mode", true};
+    GeneratorParam<bool> realtime_diaplay_mode{"realtime_diaplay_mode", false};
     
     GeneratorInput<bool> dispose{ "dispose" };
     GeneratorInput<int32_t> gain0{ "gain0" };
@@ -585,7 +585,7 @@ public:
         std::memcpy(exposure_key_buf.data(), exposure_key.c_str(), exposure_key.size());
 
         std::vector<ExternFuncArgument> params{
-            static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode),
+            static_cast<bool>(frame_sync), static_cast<bool>(realtime_diaplay_mode),
             gain0, exposure0, pixel_format_buf,
             gain_key_buf, exposure_key_buf
          };
@@ -600,7 +600,7 @@ public:
         std::memcpy(pixel_format_buf_cpy.data(), pixel_format.c_str(), pixel_format.size());
 
         Func camera1_frame_count;
-        camera1_frame_count.define_extern("ion_bb_image_io_u3v_camera1_frame_count", { camera1, dispose, 1, static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
+        camera1_frame_count.define_extern("ion_bb_image_io_u3v_camera1_frame_count", { camera1, dispose, 1, static_cast<bool>(frame_sync), static_cast<bool>(realtime_diaplay_mode), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
         camera1_frame_count.compute_root();
         frame_count(_) = camera1_frame_count(_);
     }
@@ -617,7 +617,7 @@ public:
     GeneratorParam<std::string> pixel_format_ptr{"pixel_format_ptr", "RGB8"};
     GeneratorParam<std::string> gain_key_ptr{"gain_key", "Gain"};
     GeneratorParam<std::string> exposure_key_ptr{"exposure_key", "Exposure"};
-    GeneratorParam<bool> frame_buffer_mode{"frame_buffer_mode", true};
+    GeneratorParam<bool> realtime_diaplay_mode{"realtime_diaplay_mode", false};
 
     GeneratorInput<bool> dispose{ "dispose" };
     GeneratorInput<int32_t> gain0{ "gain0" };
@@ -648,7 +648,7 @@ public:
         std::memcpy(exposure_key_buf.data(), exposure_key.c_str(), exposure_key.size());
 
         std::vector<ExternFuncArgument> params{
-            static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode),
+            static_cast<bool>(frame_sync), static_cast<bool>(realtime_diaplay_mode),
             gain0, gain1, exposure0, exposure1, pixel_format_buf,
             gain_key_buf, exposure_key_buf
          };
@@ -664,7 +664,7 @@ public:
         std::memcpy(pixel_format_buf_cpy.data(), pixel_format.c_str(), pixel_format.size());
 
         Func camera2_frame_count;
-        camera2_frame_count.define_extern("ion_bb_image_io_u3v_camera2_frame_count", { camera2, dispose, 2, static_cast<bool>(frame_sync), static_cast<bool>(frame_buffer_mode), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
+        camera2_frame_count.define_extern("ion_bb_image_io_u3v_camera2_frame_count", { camera2, dispose, 2, static_cast<bool>(frame_sync), static_cast<bool>(realtime_diaplay_mode), pixel_format_buf_cpy}, type_of<uint32_t>(), 1);
         camera2_frame_count.compute_root();
         frame_count(_) = camera2_frame_count(_);
     }

--- a/include/ion-bb-image-io/rt_u3v.h
+++ b/include/ion-bb-image-io/rt_u3v.h
@@ -209,19 +209,15 @@ class U3V {
             devices_[i].frame_count_ = static_cast<uint64_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
         }
 
-        // if (!frame_buffer_mode_){
+        if (!frame_buffer_mode_){
             // get output buffer for each stream
-            // if all stream has N output buffers, discard N-1 of them
             int32_t min_num_output_buffer = std::numeric_limits<int>::max();
             for (auto i = 0; i < num_device; ++i){
                 int32_t num_input_buffer, num_output_buffer;
                 arv_stream_get_n_buffers(devices_[i].stream_, &num_input_buffer, &num_output_buffer);
                 min_num_output_buffer = num_output_buffer < min_num_output_buffer ? num_output_buffer : min_num_output_buffer;
-                std::string comp = i == 0 ? "" : " vs ";
-                std::cout << comp << num_output_buffer;
             }
-            std::cout << "\t=> will discard " << min_num_output_buffer-1 << " frames" << std::endl;
-        if (!frame_buffer_mode_){
+            // if all stream has N output buffers, discard N-1 of them
             if (min_num_output_buffer > 1){
                 for(auto i = 0; i < num_device; ++i){
                     for (auto j = 0; j < min_num_output_buffer-1; ++j){

--- a/include/ion-bb-image-io/rt_u3v.h
+++ b/include/ion-bb-image-io/rt_u3v.h
@@ -136,7 +136,7 @@ class U3V {
     static U3V & get_instance(std::string pixel_format, int32_t num_sensor, bool frame_sync, bool frame_buffer_mode)
     {
         if (instance_ == nullptr){
-            instance_ = std::unique_ptr<U3V>(new U3V(pixel_format, num_sensor, frame_sync));
+            instance_ = std::unique_ptr<U3V>(new U3V(pixel_format, num_sensor, frame_sync, frame_buffer_mode));
         }
         return *instance_;
     }
@@ -246,8 +246,10 @@ class U3V {
     }
 
     private:
-    U3V(std::string pixel_format, int32_t num_sensor, bool frame_sync, char* dev_id = nullptr)
-    : gobject_(GOBJECT_FILE, true), aravis_(ARAVIS_FILE, true), pixel_format_(pixel_format), num_sensor_(num_sensor), frame_sync_(frame_sync), devices_(num_sensor), buffers_(num_sensor), disposed_(false)
+    U3V(std::string pixel_format, int32_t num_sensor, bool frame_sync, bool frame_buffer_mode, char* dev_id = nullptr)
+    : gobject_(GOBJECT_FILE, true), aravis_(ARAVIS_FILE, true), 
+        pixel_format_(pixel_format), num_sensor_(num_sensor), 
+        frame_sync_(frame_sync), frame_buffer_mode_(frame_buffer_mode), devices_(num_sensor), buffers_(num_sensor), disposed_(false)
     {
         init_symbols();
 
@@ -485,6 +487,7 @@ class U3V {
     GError *err_ = nullptr;
 
     bool frame_sync_;
+    bool frame_buffer_mode_;
 
     std::string pixel_format_;
 

--- a/include/ion-bb-image-io/rt_u3v.h
+++ b/include/ion-bb-image-io/rt_u3v.h
@@ -133,7 +133,7 @@ class U3V {
         }
     }
 
-    static U3V & get_instance(std::string pixel_format, int32_t num_sensor, bool frame_sync)
+    static U3V & get_instance(std::string pixel_format, int32_t num_sensor, bool frame_sync, bool frame_buffer_mode)
     {
         if (instance_ == nullptr){
             instance_ = std::unique_ptr<U3V>(new U3V(pixel_format, num_sensor, frame_sync));
@@ -499,12 +499,12 @@ class U3V {
 std::unique_ptr<U3V> U3V::instance_;
 
 int u3v_camera_frame_count(
-    bool dispose, int32_t num_sensor, bool frame_sync, halide_buffer_t * pixel_format_buf,
+    bool dispose, int32_t num_sensor, bool frame_sync, bool frame_buffer_mode, halide_buffer_t * pixel_format_buf,
     halide_buffer_t* out)
 {
     try {
         const ::std::string pixel_format(reinterpret_cast<const char*>(pixel_format_buf->host));
-        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, num_sensor, frame_sync));
+        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, num_sensor, frame_sync, frame_buffer_mode));
         if (out->is_bounds_query()) {
             out->dim[0].min = 0;
             out->dim[0].extent = 1;
@@ -531,7 +531,7 @@ int u3v_camera_frame_count(
 
 extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_camera1(
-    bool frame_sync, int32_t gain0, int32_t exposure0,
+    bool frame_sync, bool frame_buffer_mode, int32_t gain0, int32_t exposure0,
     halide_buffer_t* pixel_format_buf, halide_buffer_t * gain_key_buf, halide_buffer_t * exposure_key_buf,
     halide_buffer_t * out0)
 {
@@ -540,7 +540,7 @@ int ION_EXPORT ion_bb_image_io_u3v_camera1(
         const ::std::string gain_key(reinterpret_cast<const char*>(gain_key_buf->host));
         const ::std::string exposure_key(reinterpret_cast<const char*>(exposure_key_buf->host));
         const ::std::string pixel_format(reinterpret_cast<const char*>(pixel_format_buf->host));
-        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, 1, frame_sync));
+        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, 1, frame_sync, frame_buffer_mode));
         if (out0->is_bounds_query()) {
             //bounds query
             return 0;
@@ -566,7 +566,7 @@ ION_REGISTER_EXTERN(ion_bb_image_io_u3v_camera1);
 
 extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_camera2(
-    bool frame_sync, int32_t gain0, int32_t gain1, int32_t exposure0, int32_t exposure1,
+    bool frame_sync, bool frame_buffer_mode, int32_t gain0, int32_t gain1, int32_t exposure0, int32_t exposure1,
     halide_buffer_t* pixel_format_buf, halide_buffer_t * gain_key_buf, halide_buffer_t * exposure_key_buf,
     halide_buffer_t * out0, halide_buffer_t * out1)
 {
@@ -575,7 +575,7 @@ int ION_EXPORT ion_bb_image_io_u3v_camera2(
         const ::std::string gain_key(reinterpret_cast<const char*>(gain_key_buf->host));
         const ::std::string exposure_key(reinterpret_cast<const char*>(exposure_key_buf->host));
         const ::std::string pixel_format(reinterpret_cast<const char*>(pixel_format_buf->host));
-        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, 2, frame_sync));
+        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, 2, frame_sync, frame_buffer_mode));
         if (out0->is_bounds_query() || out1->is_bounds_query()) {
             //bounds query
             return 0;
@@ -604,10 +604,10 @@ ION_REGISTER_EXTERN(ion_bb_image_io_u3v_camera2);
 extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_camera1_frame_count(
     halide_buffer_t *,
-    bool dispose, int32_t num_sensor, bool frame_sync, halide_buffer_t * pixel_format_buf,
+    bool dispose, int32_t num_sensor, bool frame_sync, bool frame_buffer_mode, halide_buffer_t * pixel_format_buf,
     halide_buffer_t* out)
 {
-    return ion::bb::image_io::u3v_camera_frame_count(dispose, num_sensor, frame_sync, pixel_format_buf, out);
+    return ion::bb::image_io::u3v_camera_frame_count(dispose, num_sensor, frame_sync, frame_buffer_mode, pixel_format_buf, out);
 }
 ION_REGISTER_EXTERN(ion_bb_image_io_u3v_camera1_frame_count);
 
@@ -615,10 +615,10 @@ extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_camera2_frame_count(
     halide_buffer_t *,
     halide_buffer_t *,
-    bool dispose, int32_t num_sensor, bool frame_sync, halide_buffer_t * pixel_format_buf,
+    bool dispose, int32_t num_sensor, bool frame_sync, bool frame_buffer_mode, halide_buffer_t * pixel_format_buf,
     halide_buffer_t* out)
 {
-    return ion::bb::image_io::u3v_camera_frame_count(dispose, num_sensor, frame_sync, pixel_format_buf, out);
+    return ion::bb::image_io::u3v_camera_frame_count(dispose, num_sensor, frame_sync, frame_buffer_mode, pixel_format_buf, out);
 }
 ION_REGISTER_EXTERN(ion_bb_image_io_u3v_camera2_frame_count);
 


### PR DESCRIPTION
Added the param to U3V class that switch buffering frames to queue or discard them.

When `frame_buffer_mode `is `true`
* frames are queued up to max `buffer_size` (currently 1GiB)

When  `frame_buffer_mode `is `false`
* Check all streams' output buffer size
* Find max `N` for all `i` where `N` < the number of output buffer size of stream `i`
* Discard N-1frames from queue