### PR TITLE
updated ubuntu image version

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -15,7 +15,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -40,7 +40,7 @@ jobs:
         shell: bash
         run: |
             mkdir ${HOME}/halide
-            curl -L https://ion-kit.s3.us-west-2.amazonaws.com/dependencies/Halide-12.0.1-x86-64-ubuntu-18.04.tar.gz | tar zx -C ${HOME}/halide --strip-components 1
+            curl -L https://github.com/halide/Halide/releases/download/v12.0.1/Halide-12.0.1-x86-64-linux-5dabcaa9effca1067f907f6c8ea212f3d2b1d99a.tar.gz | tar zx -C ${HOME}/halide --strip-components 1
             find ${HOME}/halide -type d | xargs chmod 755
             sudo cp -r ${HOME}/halide/* /usr/
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   release-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
       - uses: actions/checkout@v2
@@ -32,7 +32,7 @@ jobs:
 
           # Halide
           mkdir ${HOME}/halide
-          curl -L https://ion-kit.s3.us-west-2.amazonaws.com/dependencies/Halide-12.0.1-x86-64-ubuntu-18.04.tar.gz | tar zx -C ${HOME}/halide --strip-components 1
+          curl -L https://github.com/halide/Halide/releases/download/v12.0.1/Halide-12.0.1-x86-64-linux-5dabcaa9effca1067f907f6c8ea212f3d2b1d99a.tar.gz | tar zx -C ${HOME}/halide --strip-components 1
           find ${HOME}/halide -type d | xargs chmod 755
           sudo mv ${HOME}/halide /usr/local/
 


### PR DESCRIPTION
Updated the version of ubuntu image from 18.04 to 20.04

> GitHub Actions: The Ubuntu 18.04 Actions runner image is being deprecated and will be removed by 12/1/22
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/