### PR TITLE
Feature/framecount update

### DIFF
--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -273,14 +273,12 @@ class U3V {
         }
     }
 
-    void get_frame_count(void * out){
+    void get_frame_count(uint32_t * out){
         if (num_sensor_ != devices_.size()){
-            uint32_t fc32 = static_cast<uint32_t>(frame_cnt_);
-            ::memcpy(reinterpret_cast<uint32_t*>(out), &fc32, sizeof(uint32_t));
+            ::memcpy(out, &frame_cnt_, sizeof(uint32_t));
         }else{
             for (int nd = 0; nd < num_sensor_; nd++){
-                uint32_t fc32 = static_cast<uint32_t>(devices_[nd].frame_count_);
-                ::memcpy(reinterpret_cast<uint32_t*>(out) + nd, &fc32, sizeof(uint32_t));
+                ::memcpy(out + nd, &devices_[nd].frame_count_, sizeof(uint32_t));
             }
         }
     }
@@ -608,7 +606,7 @@ class U3V {
     {
         init_symbols();
 
-        log::debug("ion-kit with framecount-log for 23-11-14 Update framecount display");
+        log::debug("ion-kit with framecount-log for 23-11-14 Update framecount Came1USB2");
         log::info("Using aravis-{}.{}.{}", arv_get_major_version(), arv_get_minor_version(), arv_get_micro_version());
 
         arv_update_device_list();
@@ -1048,7 +1046,7 @@ int u3v_camera_frame_count(
             out->dim[0].extent = 1;
         }
         else {
-            u3v.get_frame_count(out->host);
+            u3v.get_frame_count(reinterpret_cast<uint32_t*>(out->host));
             if(dispose){
                 u3v.dispose();
             }

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -263,9 +263,11 @@ class U3V {
         }
     }
 
-    uint32_t get_frame_count(){
-        /* assume frame_sync is ON */
-        return devices_[0].frame_count_;
+    void get_frame_count(void * out){
+        for (int nd = 0; nd < num_sensor_; nd++){
+            uint32_t fc32 = static_cast<uint32_t>(devices_[nd].frame_count_);
+            ::memcpy(reinterpret_cast<uint32_t*>(out) + nd, &fc32, sizeof(uint32_t));
+        }
     }
 
     int32_t get_frame_count_from_genDC_descriptor(ArvBuffer * buf, DeviceInfo& d){
@@ -936,7 +938,7 @@ int u3v_camera_frame_count(
             out->dim[0].extent = 1;
         }
         else {
-            * reinterpret_cast<uint32_t*>(out->host) = u3v.get_frame_count();
+            u3v.get_frame_count(out->host);
             if(dispose){
                 u3v.dispose();
             }

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -264,9 +264,14 @@ class U3V {
     }
 
     void get_frame_count(void * out){
-        for (int nd = 0; nd < num_sensor_; nd++){
-            uint32_t fc32 = static_cast<uint32_t>(devices_[nd].frame_count_);
-            ::memcpy(reinterpret_cast<uint32_t*>(out) + nd, &fc32, sizeof(uint32_t));
+        if (num_sensor_ != devices_.size()){
+            uint32_t fc32 = static_cast<uint32_t>(frame_cnt_);
+            ::memcpy(reinterpret_cast<uint32_t*>(out), &fc32, sizeof(uint32_t));
+        }else{
+            for (int nd = 0; nd < num_sensor_; nd++){
+                uint32_t fc32 = static_cast<uint32_t>(devices_[nd].frame_count_);
+                ::memcpy(reinterpret_cast<uint32_t*>(out) + nd, &fc32, sizeof(uint32_t));
+            }
         }
     }
 
@@ -953,7 +958,7 @@ int u3v_camera_frame_count(
         return 1;
     }
 }
-
+  
 }  // namespace image_io
 }  // namespace bb
 }  // namespace ion


### PR DESCRIPTION
U3V class
* It used to return only a single frame count in Halide Buffer from camera (USB) 0 regardless of the number of the connected devices
* Now it returns multiple frame counts in Halide Buffer
* Buffer length needs to be the size of uint32 * the number of devices
* For Came1USB2, it returns the latest frame count from 2 USB