### PR TITLE
Feature/image io save image

### DIFF
--- a/src/bb/image-io/bb.h
+++ b/src/bb/image-io/bb.h
@@ -929,6 +929,9 @@ public:
         fc(_) = frame_count(_);
         fc.compute_root();
 
+        int32_t dim = D;
+        int32_t byte_depth = sizeof(T);
+
         if (num_gendc==1){
             Func image;
             image(_) = input_images(_);
@@ -938,7 +941,7 @@ public:
             deviceinfo(_) = input_deviceinfo(_);
             deviceinfo.compute_root();
 
-            std::vector<ExternFuncArgument> params = { image, deviceinfo, fc, dispose, width, height, color_channel, output_directory_buf };
+            std::vector<ExternFuncArgument> params = { image, deviceinfo, fc, dispose, width, height, dim, byte_depth, output_directory_buf };
             Func ion_bb_image_io_binary_image_saver;
             ion_bb_image_io_binary_image_saver.define_extern("ion_bb_image_io_binary_1image_saver", params, Int(32), 0);
             ion_bb_image_io_binary_image_saver.compute_root();
@@ -956,7 +959,7 @@ public:
             deviceinfo0.compute_root();
             deviceinfo1.compute_root();
 
-            std::vector<ExternFuncArgument> params = { image0, image1, deviceinfo0, deviceinfo1, fc, dispose, width, height, color_channel, output_directory_buf };
+            std::vector<ExternFuncArgument> params = { image0, image1, deviceinfo0, deviceinfo1, fc, dispose, width, height, dim, byte_depth, output_directory_buf };
             Func ion_bb_image_io_binary_image_saver;
             ion_bb_image_io_binary_image_saver.define_extern("ion_bb_image_io_binary_2image_saver", params, Int(32), 0);
             ion_bb_image_io_binary_image_saver.compute_root();

--- a/src/bb/image-io/bb.h
+++ b/src/bb/image-io/bb.h
@@ -906,7 +906,7 @@ public:
     GeneratorInput<Halide::Func[]> input_images{ "input_images", Halide::type_of<T>(), D };
 
     GeneratorInput<Halide::Func[]> input_deviceinfo{ "input_deviceinfo", Halide::type_of<uint8_t>(), 1 };
-    GeneratorInput<Halide::Func> frame_count{ "frame_count", UInt(32), 1 };
+    GeneratorInput<Halide::Func> frame_count{ "frame_count", Halide::type_of<uint32_t>(), 1 };
     
     GeneratorInput<bool> dispose{ "dispose" };
     GeneratorInput<int32_t> width{ "width" };

--- a/src/bb/image-io/bb.h
+++ b/src/bb/image-io/bb.h
@@ -757,7 +757,7 @@ public:
             std::memcpy(pixel_format_buf.data(), pixel_format.c_str(), pixel_format.size());
 
             std::vector<ExternFuncArgument> params{
-                cameraN, dispose, static_cast<int32_t>(output.size()), static_cast<bool>(frame_sync), 
+                cameraN, dispose, static_cast<int32_t>(num_devices), static_cast<bool>(frame_sync), 
                 static_cast<bool>(realtime_diaplay_mode), pixel_format_buf
             };
 
@@ -874,7 +874,7 @@ public:
             std::memcpy(pixel_format_buf.data(), pixel_format.c_str(), pixel_format.size());
 
             std::vector<ExternFuncArgument> params{
-                u3v_gendc, dispose, static_cast<bool>(frame_sync), 
+                u3v_gendc, dispose, static_cast<int32_t>(num_devices), static_cast<bool>(frame_sync), 
                 static_cast<bool>(realtime_diaplay_mode), pixel_format_buf
             };
 
@@ -981,13 +981,13 @@ public:
 
     GeneratorParam<int32_t> num_devices{"num_devices", 2};
 
-    Input<Halide::Func[]> input_gendc{ "input_gendc", Halide::type_of<uint8_t>(), 1 };
-    Input<Halide::Func[]> input_deviceinfo{ "input_deviceinfo", Halide::type_of<uint8_t>(), 1 };
+    GeneratorInput<Halide::Func[]> input_gendc{ "input_gendc", Halide::type_of<uint8_t>(), 1 };
+    GeneratorInput<Halide::Func[]> input_deviceinfo{ "input_deviceinfo", Halide::type_of<uint8_t>(), 1 };
 
-    Input<bool> dispose{ "dispose" };
-    Input<int32_t> payloadsize{ "payloadsize" };
+    GeneratorInput<bool> dispose{ "dispose" };
+    GeneratorInput<int32_t> payloadsize{ "payloadsize" };
 
-    Output<int> output{ "output" };
+    GeneratorOutput<int> output{ "output" };
 
     void generate() {
         using namespace Halide;

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -186,14 +186,10 @@ public:
         buf_queue_.pop();
         size_t offset = 0;
         for (int i = 0; i < outs.size(); ++i){
-            ion::log::debug("{}", i);
             ::std::memcpy(buffer + offset, reinterpret_cast<int32_t*>(framecounts) + i, sizeof(int32_t));
-            ion::log::debug("\toffset={}\tframecount={}\t\tsize={}", offset, *(reinterpret_cast<int32_t*>(framecounts) + i), sizeof(int32_t));
             offset += sizeof(int32_t);
             ::std::memcpy(buffer + offset, outs[i], size[i]);
-            ion::log::debug("\toffset={}\t\tout[i]\t\t\tsize={}", offset, size[i]);
             offset += size[i];
-            ion::log::debug("\toffset={}", offset);
         }
         task_queue_.push(::std::make_tuple(0, buffer, offset));
         task_cv_.notify_one();
@@ -426,11 +422,11 @@ int ion_bb_image_io_binary_2gendc_saver(halide_buffer_t * in0, halide_buffer_t *
             }
             if (in2->is_bounds_query()) {
                 in2->dim[0].min = 0;
-                in2->dim[0].extent = 76;
+                in2->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
             if (in3->is_bounds_query()) {
                 in3->dim[0].min = 0;
-                in3->dim[0].extent = 76;
+                in3->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
             return 0;
         }
@@ -480,7 +476,7 @@ int ion_bb_image_io_binary_1gendc_saver(halide_buffer_t * in0, halide_buffer_t *
             }
             if (in1->is_bounds_query()) {
                 in1->dim[0].min = 0;
-                in1->dim[0].extent = 76;
+                in1->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
         }
         else {
@@ -523,6 +519,7 @@ int ion_bb_image_io_binary_1image_saver(
         int num_output = 1;
         const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
         auto& w(Writer::get_instance(std::vector<int32_t>{4147200}, output_directory));
+
         if (image->is_bounds_query() || deviceinfo->is_bounds_query() || frame_count->is_bounds_query()) {
             if (image->is_bounds_query()) {
                 image->dim[0].min = 0;
@@ -532,7 +529,7 @@ int ion_bb_image_io_binary_1image_saver(
             }
             if (deviceinfo->is_bounds_query()) {
                 deviceinfo->dim[0].min = 0;
-                deviceinfo->dim[0].extent = 76;
+                deviceinfo->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
             if (frame_count->is_bounds_query()) {
                 frame_count->dim[0].min = 0;
@@ -541,7 +538,7 @@ int ion_bb_image_io_binary_1image_saver(
             return 0;
         }
         else {
-            ion::bb::image_io::rawHeader header_info0;
+            ion::bb::image_io::rawHeader header_info0;  
             ::memcpy(&header_info0, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
             std::vector<ion::bb::image_io::rawHeader> header_infos{header_info0};
 
@@ -581,7 +578,7 @@ int ion_bb_image_io_binary_2image_saver(
         int num_output = 2;
         const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
         auto& w(Writer::get_instance(std::vector<int32_t>{4147200, 4147200}, output_directory));
-        ion::log::debug("{} {} {}", __FUNCTION__, width, height);
+
         if (image0->is_bounds_query() || deviceinfo0->is_bounds_query() || 
             image1->is_bounds_query() || deviceinfo1->is_bounds_query() || frame_count->is_bounds_query()) {
             if (image0->is_bounds_query()) {
@@ -592,7 +589,7 @@ int ion_bb_image_io_binary_2image_saver(
             }
             if (deviceinfo0->is_bounds_query()) {
                 deviceinfo0->dim[0].min = 0;
-                deviceinfo0->dim[0].extent = 76;
+                deviceinfo0->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
             if (image1->is_bounds_query()) {
                 image1->dim[0].min = 0;
@@ -602,7 +599,7 @@ int ion_bb_image_io_binary_2image_saver(
             }
             if (deviceinfo1->is_bounds_query()) {
                 deviceinfo1->dim[0].min = 0;
-                deviceinfo1->dim[0].extent = 76;
+                deviceinfo1->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
             if (frame_count->is_bounds_query()) {
                 frame_count->dim[0].min = 0;

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -543,6 +543,12 @@ int ion_bb_image_io_binary_1image_saver(
             return 0;
         }
         else {
+            if (dispose) {
+                w.dispose();
+                w.release_instance(output_directory);
+                return 0;
+            }
+            
             ion::bb::image_io::rawHeader header_info0;  
             ::memcpy(&header_info0, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
             std::vector<ion::bb::image_io::rawHeader> header_infos{header_info0};
@@ -550,12 +556,6 @@ int ion_bb_image_io_binary_1image_saver(
             std::vector<void *> obufs{image->host};
             std::vector<size_t> size_in_bytes{image->size_in_bytes()};
             w.post_images(obufs, size_in_bytes, header_infos, frame_count->host);
-
-            if (dispose) {
-                w.dispose();
-                w.release_instance(output_directory);
-                return 0;
-            }
         }
 
         return 0;
@@ -622,6 +622,11 @@ int ion_bb_image_io_binary_2image_saver(
             return 0;
         }
         else {
+            if (dispose) {
+                w.dispose();
+                w.release_instance(output_directory);
+                return 0;
+            }
             ion::bb::image_io::rawHeader header_info0, header_info1;
             ::memcpy(&header_info0, deviceinfo0->host, sizeof(ion::bb::image_io::rawHeader));
             ::memcpy(&header_info1, deviceinfo1->host, sizeof(ion::bb::image_io::rawHeader));
@@ -630,12 +635,6 @@ int ion_bb_image_io_binary_2image_saver(
             std::vector<void *> obufs{image0->host, image1->host};
             std::vector<size_t> size_in_bytes{image0->size_in_bytes(), image1->size_in_bytes()};
             w.post_images(obufs, size_in_bytes, header_infos, frame_count->host);
-
-            if (dispose) {
-                w.dispose();
-                w.release_instance(output_directory);
-                return 0;
-            }
         }
 
         return 0;

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -512,13 +512,14 @@ ION_REGISTER_EXTERN(ion_bb_image_io_binary_1gendc_saver);
 extern "C" ION_EXPORT
 int ion_bb_image_io_binary_1image_saver(
     halide_buffer_t * image, halide_buffer_t * deviceinfo, halide_buffer_t * frame_count,
-    bool dispose, int width, int height, int color_channel, halide_buffer_t*  output_directory_buf,
+    bool dispose, int width, int height, int dim, int byte_depth, halide_buffer_t*  output_directory_buf,
     halide_buffer_t * out)
     {
     try {
         int num_output = 1;
+        int32_t frame_size = dim == 2 ? width * height * byte_depth : width * height * 3 * byte_depth;
         const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
-        auto& w(Writer::get_instance(std::vector<int32_t>{4147200}, output_directory));
+        auto& w(Writer::get_instance(std::vector<int32_t>{frame_size}, output_directory));
 
         if (image->is_bounds_query() || deviceinfo->is_bounds_query() || frame_count->is_bounds_query()) {
             if (image->is_bounds_query()) {
@@ -526,6 +527,10 @@ int ion_bb_image_io_binary_1image_saver(
                 image->dim[0].extent = width;
                 image->dim[1].min = 0;
                 image->dim[1].extent = height;
+                if (dim == 3){
+                    image->dim[2].min = 0;
+                    image->dim[2].extent = 3;
+                }
             }
             if (deviceinfo->is_bounds_query()) {
                 deviceinfo->dim[0].min = 0;
@@ -571,13 +576,14 @@ extern "C" ION_EXPORT
 int ion_bb_image_io_binary_2image_saver(
     halide_buffer_t * image0, halide_buffer_t * image1, 
     halide_buffer_t * deviceinfo0, halide_buffer_t * deviceinfo1, halide_buffer_t * frame_count,
-    bool dispose, int32_t width, int32_t height, int32_t color_channel, halide_buffer_t*  output_directory_buf,
+    bool dispose, int32_t width, int32_t height, int32_t dim, int byte_depth, halide_buffer_t*  output_directory_buf,
     halide_buffer_t * out)
     {
     try {
         int num_output = 2;
+        int32_t frame_size = dim == 2 ? width * height * byte_depth : width * height * 3 * byte_depth;
         const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
-        auto& w(Writer::get_instance(std::vector<int32_t>{4147200, 4147200}, output_directory));
+        auto& w(Writer::get_instance(std::vector<int32_t>{frame_size, frame_size}, output_directory));
 
         if (image0->is_bounds_query() || deviceinfo0->is_bounds_query() || 
             image1->is_bounds_query() || deviceinfo1->is_bounds_query() || frame_count->is_bounds_query()) {
@@ -586,6 +592,10 @@ int ion_bb_image_io_binary_2image_saver(
                 image0->dim[0].extent = width;
                 image0->dim[1].min = 0;
                 image0->dim[1].extent = height;
+                if (dim == 3){
+                    image0->dim[2].min = 0;
+                    image0->dim[2].extent = 3;
+                }
             }
             if (deviceinfo0->is_bounds_query()) {
                 deviceinfo0->dim[0].min = 0;
@@ -596,6 +606,10 @@ int ion_bb_image_io_binary_2image_saver(
                 image1->dim[0].extent = width;
                 image1->dim[1].min = 0;
                 image1->dim[1].extent = height;
+                if (dim == 3){
+                    image1->dim[2].min = 0;
+                    image1->dim[2].extent = 3;
+                }
             }
             if (deviceinfo1->is_bounds_query()) {
                 deviceinfo1->dim[0].min = 0;

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -392,7 +392,8 @@ int ion_bb_image_io_binary_2gendc_saver(halide_buffer_t * in0, halide_buffer_t *
     {
     try {
         const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
-        auto& w(Writer::get_instance(std::vector<int32_t>{payloadsize, payloadsize},  output_directory));
+        std::vector<int32_t>payloadsize_list{payloadsize, payloadsize};
+        auto& w(Writer::get_instance(payloadsize_list,  output_directory));
         if (in0->is_bounds_query() || in1->is_bounds_query() || in2->is_bounds_query() || in3->is_bounds_query()) {
             int i = 1;
             if (in0->is_bounds_query()) {
@@ -451,7 +452,8 @@ int ion_bb_image_io_binary_1gendc_saver(halide_buffer_t * gendc, halide_buffer_t
     {
     try {
         const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
-        auto& w(Writer::get_instance(std::vector<int32_t>{payloadsize}, output_directory));
+        std::vector<int32_t>payloadsize_list{payloadsize};
+        auto& w(Writer::get_instance(payloadsize_list, output_directory));
         if (gendc->is_bounds_query() || deviceinfo->is_bounds_query()) {
             if (gendc->is_bounds_query()) {
                 gendc->dim[0].min = 0;

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -445,30 +445,31 @@ int ion_bb_image_io_binary_2gendc_saver(halide_buffer_t * in0, halide_buffer_t *
 ION_REGISTER_EXTERN(ion_bb_image_io_binary_2gendc_saver);
 
 extern "C" ION_EXPORT
-int ion_bb_image_io_binary_1gendc_saver(halide_buffer_t * in0, halide_buffer_t * in1,
+int ion_bb_image_io_binary_1gendc_saver(halide_buffer_t * gendc, halide_buffer_t * deviceinfo,
     bool dispose, int payloadsize, halide_buffer_t*  output_directory_buf,
     halide_buffer_t * out)
     {
     try {
         const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
         auto& w(Writer::get_instance(std::vector<int32_t>{payloadsize}, output_directory));
-        if (in0->is_bounds_query() || in1->is_bounds_query()) {
-            if (in0->is_bounds_query()) {
-                in0->dim[0].min = 0;
-                in0->dim[0].extent = payloadsize;
+        if (gendc->is_bounds_query() || deviceinfo->is_bounds_query()) {
+            if (gendc->is_bounds_query()) {
+                gendc->dim[0].min = 0;
+                gendc->dim[0].extent = payloadsize;
             }
-            if (in1->is_bounds_query()) {
-                in1->dim[0].min = 0;
-                in1->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
+            if (deviceinfo->is_bounds_query()) {
+                deviceinfo->dim[0].min = 0;
+                deviceinfo->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
+            return 0;
         }
         else {
             ion::bb::image_io::rawHeader header_info0;
-            ::memcpy(&header_info0, in1->host, sizeof(ion::bb::image_io::rawHeader));
+            ::memcpy(&header_info0, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
             std::vector<ion::bb::image_io::rawHeader> header_infos{header_info0};
 
-            std::vector<void *> obufs{in0->host};
-            std::vector<size_t> size_in_bytes{in0->size_in_bytes()};
+            std::vector<void *> obufs{gendc->host};
+            std::vector<size_t> size_in_bytes{gendc->size_in_bytes()};
             w.post_gendc(obufs, size_in_bytes, header_infos);
 
             if (dispose) {

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -12,6 +12,8 @@
 
 #include "json/json.hpp"
 
+#include "log.h"
+
 #include "rt_common.h"
 #include "httplib.h"
 
@@ -169,6 +171,32 @@ public:
         task_cv_.notify_one();
     }
 
+    void post_images(std::vector<void *>& outs, std::vector<size_t>& size, 
+                    std::vector<ion::bb::image_io::rawHeader>& header_infos, void* framecounts)
+    {
+        if (with_header_){
+            write_config_file(header_infos);
+        }
+        ::std::unique_lock<::std::mutex> lock(mutex_);
+        buf_cv_.wait(lock, [&] { return !buf_queue_.empty() || ep_; });
+        if (ep_) {
+            ::std::rethrow_exception(ep_);
+        }
+        uint8_t* buffer = buf_queue_.front();
+        buf_queue_.pop();
+        size_t offset = 0;
+        for (int i = 0; i < outs.size(); ++i){
+            ::ion::log::debug("framecount[{}] = {}", i, *(reinterpret_cast<int32_t*>(framecounts) + i));
+            ::std::memcpy(buffer + offset, reinterpret_cast<int32_t*>(framecounts) + i, sizeof(int32_t));
+            offset += sizeof(int32_t);
+            ::ion::log::debug("offset:{}   size[{}]:{}", offset, i, size[i]);
+            ::std::memcpy(buffer + offset, outs[i], size[i]);
+            offset += size[i];
+            ::ion::log::debug("offset:{}", offset);
+        }
+        task_queue_.push(::std::make_tuple(0, buffer, offset));
+        task_cv_.notify_one();
+    }
 
     void post_gendc(std::vector<void *>& outs, std::vector<size_t>& size, std::vector<ion::bb::image_io::rawHeader>& header_infos)
     {
@@ -578,6 +606,134 @@ int ion_bb_image_io_binary_1gendc_saver(halide_buffer_t * in0, halide_buffer_t *
 }
 
 ION_REGISTER_EXTERN(ion_bb_image_io_binary_1gendc_saver);
+
+extern "C" ION_EXPORT
+int ion_bb_image_io_binary_1image_saver(
+    halide_buffer_t * image, halide_buffer_t * deviceinfo, halide_buffer_t * frame_count,
+    bool dispose, int width, int height, int color_channel, halide_buffer_t*  output_directory_buf,
+    halide_buffer_t * out)
+    {
+    try {
+        int num_output = 1;
+        const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
+        auto& w(Writer::get_instance(4147200, output_directory, false));
+        if (image->is_bounds_query() || deviceinfo->is_bounds_query() || frame_count->is_bounds_query()) {
+            if (image->is_bounds_query()) {
+                image->dim[0].min = 0;
+                image->dim[0].extent = width;
+                image->dim[1].min = 0;
+                image->dim[1].extent = height;
+            }
+            if (deviceinfo->is_bounds_query()) {
+                deviceinfo->dim[0].min = 0;
+                deviceinfo->dim[0].extent = 76;
+            }
+            if (frame_count->is_bounds_query()) {
+                frame_count->dim[0].min = 0;
+                frame_count->dim[0].extent = num_output;
+            }
+            return 0;
+        }
+        else {
+            ion::bb::image_io::rawHeader header_info0;
+            ::memcpy(&header_info0, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
+            std::vector<ion::bb::image_io::rawHeader> header_infos{header_info0};
+
+            std::vector<void *> obufs{image->host};
+            std::vector<size_t> size_in_bytes{image->size_in_bytes()};
+            w.post_images(obufs, size_in_bytes, header_infos, frame_count->host);
+
+            if (dispose) {
+                w.dispose();
+                w.release_instance(output_directory);
+                return 0;
+            }
+        }
+
+        return 0;
+    }
+    catch (const ::std::exception& e) {
+        ::std::cerr << e.what() << ::std::endl;
+        return -1;
+    }
+    catch (...) {
+        ::std::cerr << "Unknown error" << ::std::endl;
+        return -1;
+    }
+}
+
+ION_REGISTER_EXTERN(ion_bb_image_io_binary_1image_saver);
+
+extern "C" ION_EXPORT
+int ion_bb_image_io_binary_2image_saver(
+    halide_buffer_t * image0, halide_buffer_t * image1, 
+    halide_buffer_t * deviceinfo0, halide_buffer_t * deviceinfo1, halide_buffer_t * frame_count,
+    bool dispose, int32_t width, int32_t height, int32_t color_channel, halide_buffer_t*  output_directory_buf,
+    halide_buffer_t * out)
+    {
+    try {
+        int num_output = 2;
+        const ::std::string output_directory(reinterpret_cast<const char*>(output_directory_buf->host));
+        auto& w(Writer::get_instance(4147200, output_directory, false));
+        ion::log::debug("{} {} {}", __FUNCTION__, width, height);
+        if (image0->is_bounds_query() || deviceinfo0->is_bounds_query() || 
+            image1->is_bounds_query() || deviceinfo1->is_bounds_query() || frame_count->is_bounds_query()) {
+            if (image0->is_bounds_query()) {
+                image0->dim[0].min = 0;
+                image0->dim[0].extent = width;
+                image0->dim[1].min = 0;
+                image0->dim[1].extent = height;
+            }
+            if (deviceinfo0->is_bounds_query()) {
+                deviceinfo0->dim[0].min = 0;
+                deviceinfo0->dim[0].extent = 76;
+            }
+            if (image1->is_bounds_query()) {
+                image1->dim[0].min = 0;
+                image1->dim[0].extent = width;
+                image1->dim[1].min = 0;
+                image1->dim[1].extent = height;
+            }
+            if (deviceinfo1->is_bounds_query()) {
+                deviceinfo1->dim[0].min = 0;
+                deviceinfo1->dim[0].extent = 76;
+            }
+            if (frame_count->is_bounds_query()) {
+                frame_count->dim[0].min = 0;
+                frame_count->dim[0].extent = num_output;
+            }
+            return 0;
+        }
+        else {
+            ion::bb::image_io::rawHeader header_info0, header_info1;
+            ::memcpy(&header_info0, deviceinfo0->host, sizeof(ion::bb::image_io::rawHeader));
+            ::memcpy(&header_info1, deviceinfo1->host, sizeof(ion::bb::image_io::rawHeader));
+            std::vector<ion::bb::image_io::rawHeader> header_infos{header_info0, header_info1};
+
+            std::vector<void *> obufs{image0->host, image1->host};
+            std::vector<size_t> size_in_bytes{image0->size_in_bytes(), image1->size_in_bytes()};
+            w.post_images(obufs, size_in_bytes, header_infos, frame_count->host);
+
+            if (dispose) {
+                w.dispose();
+                w.release_instance(output_directory);
+                return 0;
+            }
+        }
+
+        return 0;
+    }
+    catch (const ::std::exception& e) {
+        ::std::cerr << e.what() << ::std::endl;
+        return -1;
+    }
+    catch (...) {
+        ::std::cerr << "Unknown error" << ::std::endl;
+        return -1;
+    }
+}
+
+ION_REGISTER_EXTERN(ion_bb_image_io_binary_2image_saver);
 
 namespace {
 

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -618,7 +618,7 @@ class U3V {
     {
         init_symbols();
 
-        log::debug("ion-kit with framecount-log for 23-11-14 Update framecount Came1USB2");
+        log::debug("ion-kit with framecount-log for 23-11-14 Update realtime-display-mode Came1USB2");
         log::info("Using aravis-{}.{}.{}", arv_get_major_version(), arv_get_minor_version(), arv_get_micro_version());
 
         arv_update_device_list();

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -618,7 +618,7 @@ class U3V {
     {
         init_symbols();
 
-        log::debug("ion-kit ======================================== 23-11-16 Testing new BBs");
+        log::debug("U3V class ======================================== 23-11-17 Testing new BBs");
         log::info("Using aravis-{}.{}.{}", arv_get_major_version(), arv_get_minor_version(), arv_get_micro_version());
 
         arv_update_device_list();

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -1419,7 +1419,6 @@ int ION_EXPORT ion_bb_image_io_u3v_multiple_camera2(
                 u3v.SetGain(i, gain_key, (reinterpret_cast<double*>(gain->host))[i]);
                 u3v.SetExposure(i, exposure_key, (reinterpret_cast<double*>(exposure->host))[i]);
             }
-            ion::log::debug("{} {}", out0->size_in_bytes(), out1->size_in_bytes());
             std::vector<void *> obufs{out0->host, out1->host};
             u3v.get(obufs);
             if(dispose){

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -618,7 +618,7 @@ class U3V {
     {
         init_symbols();
 
-        log::debug("U3V class ======================================== 23-11-17 Testing new BBs");
+        log::debug("U3V:: 23-11-18 : updating obtain and write");
         log::info("Using aravis-{}.{}.{}", arv_get_major_version(), arv_get_minor_version(), arv_get_micro_version());
 
         arv_update_device_list();
@@ -1057,6 +1057,7 @@ int u3v_camera_frame_count(
         if (out->is_bounds_query()) {
             out->dim[0].min = 0;
             out->dim[0].extent = num_sensor;
+            return 0;
         }
         else {
             u3v.get_frame_count(reinterpret_cast<uint32_t*>(out->host));
@@ -1284,7 +1285,7 @@ int ION_EXPORT ion_bb_image_io_u3v_device_info1(
 
         if (out_deviceinfo->is_bounds_query()){
             out_deviceinfo->dim[0].min = 0;
-            out_deviceinfo->dim[0].extent = 76;
+            out_deviceinfo->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             return 0;
         }else{
             std::vector<void *> obufs{out_deviceinfo->host};
@@ -1322,11 +1323,11 @@ int ION_EXPORT ion_bb_image_io_u3v_device_info2(
         if (deviceinfo0->is_bounds_query() || deviceinfo1->is_bounds_query()) {
             if (deviceinfo0->is_bounds_query()){
                 deviceinfo0->dim[0].min = 0;
-                deviceinfo0->dim[0].extent = 76;
+                deviceinfo0->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
             if (deviceinfo1->is_bounds_query()){
                 deviceinfo1->dim[0].min = 0;
-                deviceinfo1->dim[0].extent = 76;
+                deviceinfo1->dim[0].extent = sizeof(ion::bb::image_io::rawHeader);
             }
             return 0;
         }else{

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -544,8 +544,8 @@ class U3V {
             }
 
             for (int i = 0; i < num_sensor_; ++i){
-                ::memcpy(outs[i*num_sensor_], arv_buffer_get_data(bufs[i], nullptr), devices_[i].u3v_payload_size_);
-                ::memcpy(outs[i*num_sensor_+1], &(devices_[i].header_info_), sizeof(ion::bb::image_io::rawHeader));
+                ::memcpy(outs[i], arv_buffer_get_data(bufs[i], nullptr), devices_[i].u3v_payload_size_);
+                // ::memcpy(outs[i*num_sensor_+1], &(devices_[i].header_info_), sizeof(ion::bb::image_io::rawHeader));
                 arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
                 log::trace("Obtained Frame from USB{}: {}", i, devices_[i].frame_count_);
             }
@@ -592,8 +592,20 @@ class U3V {
 
                 frame_cnt_ = latest_cnt;
                 ::memcpy(outs[0], arv_buffer_get_data(bufs[cameN_idx_], nullptr), devices_[cameN_idx_].u3v_payload_size_);
-                ::memcpy(outs[1], &(devices_[cameN_idx_].header_info_), sizeof(ion::bb::image_io::rawHeader));
+                // ::memcpy(outs[1], &(devices_[cameN_idx_].header_info_), sizeof(ion::bb::image_io::rawHeader));
                 arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
+        }
+    }
+
+    void get_device_info(std::vector<void *>& outs){
+        if (operation_mode_ == OperationMode::Came2USB2 || operation_mode_ == OperationMode::Came1USB1){
+            for (int i = 0; i < num_sensor_; ++i){
+                ::memcpy(outs[i], &(devices_[i].header_info_), sizeof(ion::bb::image_io::rawHeader));
+                log::trace("Obtained Device info USB{}", i);
+            }
+        } else if (operation_mode_ == OperationMode::Came1USB2) {
+            ::memcpy(outs[0], &(devices_[cameN_idx_].header_info_), sizeof(ion::bb::image_io::rawHeader));
+            log::trace("Obtained Device info (OperationMode::Came1USB2)");
         }
     }
 
@@ -1166,7 +1178,7 @@ int ION_EXPORT ion_bb_image_io_u3v_gendc_camera1(
     bool frame_sync, bool realtime_display_mode,
     halide_buffer_t* gain, halide_buffer_t* exposure,
     halide_buffer_t* pixel_format_buf, halide_buffer_t * gain_key_buf, halide_buffer_t * exposure_key_buf,
-    halide_buffer_t * out_gendc, halide_buffer_t * out_deviceinfo
+    halide_buffer_t * out_gendc
     )
 {
     using namespace Halide;
@@ -1176,7 +1188,7 @@ int ION_EXPORT ion_bb_image_io_u3v_gendc_camera1(
         const ::std::string exposure_key(reinterpret_cast<const char*>(exposure_key_buf->host));
         const ::std::string pixel_format(reinterpret_cast<const char*>(pixel_format_buf->host));
         auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, num_output, false, realtime_display_mode));
-        if (out_gendc->is_bounds_query() || out_deviceinfo->is_bounds_query() || gain->is_bounds_query() || exposure->is_bounds_query()) {
+        if (out_gendc->is_bounds_query() || gain->is_bounds_query() || exposure->is_bounds_query()) {
             gain->dim[0].min = 0;
             gain->dim[0].extent = num_output;
             exposure->dim[0].min = 0;
@@ -1188,8 +1200,7 @@ int ION_EXPORT ion_bb_image_io_u3v_gendc_camera1(
                 u3v.SetGain(i, gain_key, (reinterpret_cast<double*>(gain->host))[i]);
                 u3v.SetExposure(i, exposure_key, (reinterpret_cast<double*>(exposure->host))[i]);
             }
-
-            std::vector<void *> obufs{out_gendc->host, out_deviceinfo->host};
+            std::vector<void *> obufs{out_gendc->host};
             u3v.get_with_gendc(obufs);
 
             if(dispose){
@@ -1214,8 +1225,7 @@ int ION_EXPORT ion_bb_image_io_u3v_gendc_camera2(
     bool frame_sync, bool realtime_display_mode,
     halide_buffer_t* gain, halide_buffer_t* exposure,
     halide_buffer_t* pixel_format_buf, halide_buffer_t * gain_key_buf, halide_buffer_t * exposure_key_buf,
-    halide_buffer_t * gendc0, halide_buffer_t * gendc1,
-    halide_buffer_t * deviceinfo0, halide_buffer_t * deviceinfo1
+    halide_buffer_t * gendc0, halide_buffer_t * gendc1
     )
 {
     using namespace Halide;
@@ -1238,14 +1248,13 @@ int ION_EXPORT ion_bb_image_io_u3v_gendc_camera2(
                 u3v.SetExposure(i, exposure_key, (reinterpret_cast<double*>(exposure->host))[i]);
             }
 
-            std::vector<void *> obufs{gendc0->host, gendc1->host,deviceinfo0->host, deviceinfo1->host};
+            std::vector<void *> obufs{gendc0->host, gendc1->host};
             u3v.get_with_gendc(obufs);
 
             if(dispose){
                 u3v.dispose();
             }
         }
-
         return 0;
     } catch (const std::exception &e) {
         ion::log::error("Exception was thrown: {}", e.what());
@@ -1256,6 +1265,76 @@ int ION_EXPORT ion_bb_image_io_u3v_gendc_camera2(
     }
 }
 ION_REGISTER_EXTERN(ion_bb_image_io_u3v_gendc_camera2);
+
+extern "C"
+int ION_EXPORT ion_bb_image_io_u3v_device_info1(
+    halide_buffer_t *,
+    bool dispose,
+    bool frame_sync, bool realtime_display_mode,
+    halide_buffer_t* pixel_format_buf,
+    halide_buffer_t * out_deviceinfo
+    )
+{
+    using namespace Halide;
+    int num_output = 1;
+    try {
+        const ::std::string pixel_format(reinterpret_cast<const char*>(pixel_format_buf->host));
+        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, num_output, false, realtime_display_mode));
+        if (out_deviceinfo->is_bounds_query()) {
+            return 0;
+        }else{
+            std::vector<void *> obufs{out_deviceinfo->host};
+            u3v.get_device_info(obufs);
+
+            if(dispose){
+                u3v.dispose();
+            }
+        }
+        return 0;
+    } catch (const std::exception &e) {
+        ion::log::error("Exception was thrown: {}", e.what());
+        return 1;
+    } catch (...) {
+        ion::log::error("Unknown exception was thrown");
+        return 1;
+    }
+}
+ION_REGISTER_EXTERN(ion_bb_image_io_u3v_device_info1);
+
+extern "C"
+int ION_EXPORT ion_bb_image_io_u3v_device_info2(
+    halide_buffer_t *,
+    bool dispose,
+    bool frame_sync, bool realtime_display_mode,
+    halide_buffer_t* pixel_format_buf, 
+    halide_buffer_t * deviceinfo0, halide_buffer_t * deviceinfo1
+    )
+{
+    using namespace Halide;
+    try {
+        int num_output = 2;
+        const ::std::string pixel_format(reinterpret_cast<const char*>(pixel_format_buf->host));
+        auto &u3v(ion::bb::image_io::U3V::get_instance(pixel_format, 2, frame_sync, realtime_display_mode));
+        if (deviceinfo0->is_bounds_query() || deviceinfo1->is_bounds_query()) {
+            return 0;
+        }else{
+            std::vector<void *> obufs{deviceinfo0->host, deviceinfo1->host};
+            u3v.get_device_info(obufs);
+
+            if(dispose){
+                u3v.dispose();
+            }
+        }
+        return 0;
+    } catch (const std::exception &e) {
+        ion::log::error("Exception was thrown: {}", e.what());
+        return 1;
+    } catch (...) {
+        ion::log::error("Unknown exception was thrown");
+        return 1;
+    }
+}
+ION_REGISTER_EXTERN(ion_bb_image_io_u3v_device_info2);
 
 extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_multiple_camera1(


### PR DESCRIPTION
1. made `device_info`, the output of `U3VCameraN`  optional
2. made `device_info`, the output of `BinaryGenDCSaver` optional
3. Allows `image_io_binarysaver` to treat U8x3, U8x2, and U8x3
4. Organize writer class