### PR TITLE
switch USB only when the popped frame is valid

### DIFF
--- a/src/bb/image-io/rt_common.h
+++ b/src/bb/image-io/rt_common.h
@@ -14,6 +14,8 @@
 #include <opencv2/imgproc.hpp>
 #endif
 
+#include "log.h"
+
 #include "httplib.h"
 #include "zip_file.hpp"
 
@@ -52,6 +54,7 @@ public:
 #endif
 
     DynamicModule(const std::string &module_name, bool essential) {
+        ion::log::debug("Load module : Trying to load {}", module_name);
         if (module_name == "") {
             handle_ = nullptr;
             return;
@@ -59,6 +62,7 @@ public:
 
 #ifdef _WIN32
         auto file_name = module_name + ".dll";
+        ion::log::debug("Load module : Looking for {}", file_name);
         handle_ = LoadLibraryA(file_name.c_str());
 
         if (handle_ != nullptr){
@@ -67,10 +71,12 @@ public:
         }
 
         file_name = "lib" + file_name;
+        ion::log::debug("Load module : Looking for {}", file_name);
         handle_ = LoadLibraryA(file_name.c_str());
 
 #else
         auto file_name = "lib" + module_name + ".so";
+        ion::log::debug("Load module : Looking for {}", file_name);
         handle_ = dlopen(file_name.c_str(), RTLD_NOW);
 #endif
 

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -619,26 +619,26 @@ class U3V {
             int internal_count = 0;
             int max_internal_count = 1000;
 
-            while (frame_cnt_ >= latest_cnt) {
-                arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
-                auto timeout2_us = 30 * 1000 * 1000;
-                bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, timeout2_us);
-                if (bufs[cameN_idx_] == nullptr){
-                    log::error("pop_buffer(L8) failed due to timeout ({}s)", timeout2_us*1e-6f);
-                        throw ::std::runtime_error("buffer is null");
+                while (frame_cnt_ >= latest_cnt) {
+                    arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
+                    auto timeout2_us = 30 * 1000 * 1000;
+                    bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, timeout2_us);
+                    if (bufs[cameN_idx_] == nullptr){
+                        log::error("pop_buffer(L8) failed due to timeout ({}s)", timeout2_us*1e-6f);
+                            throw ::std::runtime_error("buffer is null");
+                    }
+                    devices_[cameN_idx_].frame_count_ = is_gendc_
+                            ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
+                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
+                    cameN_idx_ == 0 ? 
+                        log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
+                        log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
+                    latest_cnt = devices_[cameN_idx_].frame_count_;
+                    if (internal_count++ > max_internal_count){
+                        log::error("pop_buffer(L10) The sequential invalid buffer is more than {}; Stop the pipeline.", max_internal_count);
+                        throw ::std::runtime_error("Invalid framecount");
+                    }
                 }
-                devices_[cameN_idx_].frame_count_ = is_gendc_
-                        ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                        : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
-                cameN_idx_ == 0 ? 
-                    log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[cameN_idx_].frame_count_, "") :
-                    log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[cameN_idx_].frame_count_);
-                latest_cnt = devices_[cameN_idx_].frame_count_;
-                if (internal_count++ > max_internal_count){
-                    log::error("pop_buffer(L10) The sequential invalid buffer is more than {}; Stop the pipeline.", max_internal_count);
-                    throw ::std::runtime_error("Invalid framecount");
-                }
-            }
 
             frame_cnt_ = latest_cnt;
             ::memcpy(outs[0], arv_buffer_get_data(bufs[cameN_idx_], nullptr), devices_[cameN_idx_].u3v_payload_size_);

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -442,7 +442,6 @@ class U3V {
 
             while (frame_cnt_ >= latest_cnt) {
                 arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
-                cameN_idx_ = (cameN_idx_+1) >= num_device ? 0 : cameN_idx_+1;
                 bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, 30 * 1000 * 1000);
                 if (bufs[cameN_idx_] == nullptr){
                     log::error("pop_buffer(L4) failed due to timeout ({}s)", timeout_us*1e-6f);
@@ -572,81 +571,80 @@ class U3V {
                 log::trace("Obtained Frame from USB{}: {}", i, devices_[i].frame_count_);
             }
         } else if (operation_mode_ == OperationMode::Came1USB2) {
-                uint32_t latest_cnt = 0;
-                int32_t min_frame_device_idx = 0;
+            uint32_t latest_cnt = 0;
+            int32_t min_frame_device_idx = 0;
 
-                // if aravis output queue length is more than N (where N > 1) for all devices, pop all N-1 buffer
-                if (realtime_display_mode_){
-                    std::vector<int32_t> N_output_buffers(num_device);
-                    for (auto i = 0; i < num_device; ++i){
-                        int32_t num_input_buffer;
-                        arv_stream_get_n_buffers(devices_[i].stream_, &num_input_buffer,  &(N_output_buffers[i]));
-                    }
-                    // if all stream has N output buffers, discard N-1 of them
-                    for(auto i = 0; i < num_device; ++i){
-                        for (auto j = 0; j < N_output_buffers[i]-1; ++j){
-                            
-                            bufs[i] = arv_stream_timeout_pop_buffer (devices_[i].stream_, timeout_us);
-                            if (bufs[i] == nullptr){
-                                log::error("pop_buffer(L12) failed due to timeout ({}s)", timeout_us*1e-6f);
-                                throw ::std::runtime_error("buffer is null");
-                            }
-                            devices_[i].frame_count_ = is_gendc_
-                                ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                                : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
-                            i == 0 ? 
-                                log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
-                                log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
-                            arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
+            // if aravis output queue length is more than N (where N > 1) for all devices, pop all N-1 buffer
+            if (realtime_display_mode_){
+                std::vector<int32_t> N_output_buffers(num_device);
+                for (auto i = 0; i < num_device; ++i){
+                    int32_t num_input_buffer;
+                    arv_stream_get_n_buffers(devices_[i].stream_, &num_input_buffer,  &(N_output_buffers[i]));
+                }
+                // if all stream has N output buffers, discard N-1 of them
+                for(auto i = 0; i < num_device; ++i){
+                    for (auto j = 0; j < N_output_buffers[i]-1; ++j){
+                        
+                        bufs[i] = arv_stream_timeout_pop_buffer (devices_[i].stream_, timeout_us);
+                        if (bufs[i] == nullptr){
+                            log::error("pop_buffer(L12) failed due to timeout ({}s)", timeout_us*1e-6f);
+                            throw ::std::runtime_error("buffer is null");
                         }
+                        devices_[i].frame_count_ = is_gendc_
+                            ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
+                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                        i == 0 ? 
+                            log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
+                            log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
+                        arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
                     }
                 }
+            }
 
-                //first buffer 
-                cameN_idx_ = (cameN_idx_+1) >= num_device ? 0 : cameN_idx_+1;
-                bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, 30 * 1000 * 1000);
+            //first buffer 
+            cameN_idx_ = (cameN_idx_+1) >= num_device ? 0 : cameN_idx_+1;
+            bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, 30 * 1000 * 1000);
+            if (bufs[cameN_idx_] == nullptr){
+                log::error("pop_buffer(L4) failed due to timeout ({}s)", timeout_us*1e-6f);
+                throw ::std::runtime_error("buffer is null");
+            }
+            devices_[cameN_idx_].frame_count_ = is_gendc_
+                    ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
+                    : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
+            latest_cnt = devices_[cameN_idx_].frame_count_;
+            cameN_idx_ == 0 ?    
+                log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
+                log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
+
+            int internal_count = 0;
+            int max_internal_count = 1000;
+
+            while (frame_cnt_ >= latest_cnt) {
+                arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
+                auto timeout2_us = 30 * 1000 * 1000;
+                bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, timeout2_us);
                 if (bufs[cameN_idx_] == nullptr){
-                    log::error("pop_buffer(L4) failed due to timeout ({}s)", timeout_us*1e-6f);
-                    throw ::std::runtime_error("buffer is null");
+                    log::error("pop_buffer(L8) failed due to timeout ({}s)", timeout2_us*1e-6f);
+                        throw ::std::runtime_error("buffer is null");
                 }
                 devices_[cameN_idx_].frame_count_ = is_gendc_
                         ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
                         : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
+                cameN_idx_ == 0 ? 
+                    log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[cameN_idx_].frame_count_, "") :
+                    log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[cameN_idx_].frame_count_);
                 latest_cnt = devices_[cameN_idx_].frame_count_;
-                cameN_idx_ == 0 ?    
-                    log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
-                    log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
-
-                int internal_count = 0;
-                int max_internal_count = 1000;
-
-                while (frame_cnt_ >= latest_cnt) {
-                    arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
-                    cameN_idx_ = (cameN_idx_+1) >= num_device ? 0 : cameN_idx_+1;
-                    auto timeout2_us = 30 * 1000 * 1000;
-                    bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, timeout2_us);
-                    if (bufs[cameN_idx_] == nullptr){
-                        log::error("pop_buffer(L8) failed due to timeout ({}s)", timeout2_us*1e-6f);
-                            throw ::std::runtime_error("buffer is null");
-                    }
-                    devices_[cameN_idx_].frame_count_ = is_gendc_
-                            ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
-                    cameN_idx_ == 0 ? 
-                        log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[cameN_idx_].frame_count_, "") :
-                        log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[cameN_idx_].frame_count_);
-                    latest_cnt = devices_[cameN_idx_].frame_count_;
-                    if (internal_count++ > max_internal_count){
-                        log::error("pop_buffer(L10) The sequential invalid buffer is more than {}; Stop the pipeline.", max_internal_count);
-                        throw ::std::runtime_error("Invalid framecount");
-                    }
+                if (internal_count++ > max_internal_count){
+                    log::error("pop_buffer(L10) The sequential invalid buffer is more than {}; Stop the pipeline.", max_internal_count);
+                    throw ::std::runtime_error("Invalid framecount");
                 }
+            }
 
-                frame_cnt_ = latest_cnt;
-                ::memcpy(outs[0], arv_buffer_get_data(bufs[cameN_idx_], nullptr), devices_[cameN_idx_].u3v_payload_size_);
-                // ::memcpy(outs[1], &(devices_[cameN_idx_].header_info_), sizeof(ion::bb::image_io::rawHeader));
-                arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
-                log::trace("Obtained Frame from USB{}: {}", cameN_idx_, frame_cnt_);
+            frame_cnt_ = latest_cnt;
+            ::memcpy(outs[0], arv_buffer_get_data(bufs[cameN_idx_], nullptr), devices_[cameN_idx_].u3v_payload_size_);
+            // ::memcpy(outs[1], &(devices_[cameN_idx_].header_info_), sizeof(ion::bb::image_io::rawHeader));
+            arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
+            log::trace("Obtained Frame from USB{}: {}", cameN_idx_, frame_cnt_);
         }
     }
 


### PR DESCRIPTION
For a single sensor with 2 USB cables, switch the target USB only when the popped frame is valid (grater than the prev frame count)

## Prior to the modification（frame-drop rate 50%）
```
USB0       3   5   7   9 
USB1         2   4   6   8 

chosen USB 0 1 0 1 0 1 0 1 
obtained   3 X 5 X 7 X 9 X 
```

## Following the modification（frame-drop rate 13%）
```
USB0       3   5   7   9 
USB1         2   4   6   8 

chosen USB 0 1   1 0 1 0 1 0 
obtained   3 X   4 5 6 7 8 9
```