### PR TITLE
limit the number of device to access for Came1USB1

### DIFF
--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -685,6 +685,7 @@ class U3V {
 
         unsigned int target_device_idx;
         if (n_devices != num_sensor_ && dev_id == nullptr) {
+            n_devices = num_sensor_;
             log::info("Multiple devices are found; The first device is selected");
         }
 


### PR DESCRIPTION
Currently U3V class tries to access all connected devices; pick the first N devices where N is user specified number

* limit the number of device to access for Came1USB1
* confirmed to work on Came1USB2 too

Note: if the user set N = 2 and the operation mode is Came1USB1, it causes the error as its expectation