### PR TITLE
Feature/builder dispose hook

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -70,7 +70,7 @@ target_include_directories(ion-core PUBLIC ${PROJECT_SOURCE_DIR}/include ${PROJE
 if (UNIX)
   target_link_libraries(ion-core PUBLIC Halide::Halide Halide::Runtime dl pthread z m stdc++)
 else()
-  target_link_libraries(ion-core PUBLIC Halide::Halide Halide::Runtime m stdc++)
+  target_link_libraries(ion-core PUBLIC Halide::Halide Halide::Runtime)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,7 +22,7 @@ option(WITH_CUDA "Enable CUDA with buliding examples." ON)
 # CMake common settings
 #
 set(CMAKE_C_STANDARD 11)
-set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_EXTENSIONS OFF)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # This is required to export symbols on windows platform
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
@@ -68,9 +68,9 @@ list(REMOVE_ITEM ION_CORE_SRC "${PROJECT_SOURCE_DIR}/src/generator.cc")
 add_library(ion-core SHARED ${ION_CORE_SRC})
 target_include_directories(ion-core PUBLIC ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src)
 if (UNIX)
-  target_link_libraries(ion-core PUBLIC Halide::Halide Halide::Runtime dl pthread z)
+  target_link_libraries(ion-core PUBLIC Halide::Halide Halide::Runtime dl pthread z m stdc++)
 else()
-  target_link_libraries(ion-core PUBLIC Halide::Halide Halide::Runtime)
+  target_link_libraries(ion-core PUBLIC Halide::Halide Halide::Runtime m stdc++)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -32,7 +32,7 @@ set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 # Dependent libraries
 #
 find_package(Halide REQUIRED COMPONENTS shared)
-if (WITH_CUDA)
+if (${WITH_CUDA})
     find_package(CUDA REQUIRED)
 endif()
 

--- a/cmake/IonUtil.cmake
+++ b/cmake/IonUtil.cmake
@@ -18,9 +18,8 @@ function(ion_compile NAME)
     # Build compile
     add_executable(${NAME} ${IEC_SRCS})
     if(UNIX)
-        target_compile_options(${NAME}
-            PUBLIC -fno-rtti  # For Halide::Generator
-            PUBLIC -rdynamic) # For JIT compiling
+        target_compile_options(${NAME} PUBLIC -fno-rtti)  # For Halide::Generator
+        target_link_options(${NAME} PUBLIC -Wl,--export-dynamic) # For JIT compiling
     endif()
     target_include_directories(${NAME} PUBLIC "${PROJECT_SOURCE_DIR}/include")
     target_link_libraries(${NAME} PRIVATE ion-core ${PLATFORM_LIBRARIES})
@@ -94,8 +93,7 @@ function(ion_jit NAME)
     cmake_parse_arguments(IEJ "${options}" "${oneValueArgs}" "${multiValueArgs}" ${ARGN})
     add_executable(${NAME} ${IEJ_SRCS})
     if (UNIX)
-        # For JIT compiling
-        target_compile_options(${NAME} PUBLIC -rdynamic)
+        target_link_options(${NAME} PUBLIC -Wl,--export-dynamic) # For JIT compiling
     endif()
     find_package(OpenCV 4 REQUIRED)
     target_include_directories(${NAME} PUBLIC ${PROJECT_SOURCE_DIR}/include ${ION_BB_INCLUDE_DIRS} ${OpenCV_INCLUDE_DIRS})

--- a/include/ion/builder.h
+++ b/include/ion/builder.h
@@ -10,7 +10,6 @@
 
 #include "def.h"
 #include "buffer.h"
-#include "building_block.h"
 #include "node.h"
 #include "port_map.h"
 
@@ -23,14 +22,16 @@ class DynamicModule;
  */
 class Builder {
 public:
-     /**
-      * CompileOption class holds option field for compilation.
-      */
-     struct CompileOption {
-         std::string output_directory;
-     };
+    /**
+     * CompileOption class holds option field for compilation.
+     */
+    struct CompileOption {
+        std::string output_directory;
+    };
 
     Builder();
+
+    ~Builder();
 
     /**
      * Adding new node to the graph.
@@ -92,6 +93,13 @@ public:
     const std::vector<Node>& nodes() const { return nodes_; }
     std::vector<Node>& nodes() { return nodes_; }
 
+
+    /**
+     * Register disposer hook which will be called from Builder destructor.
+     * This is available only for JIT mode.
+     */
+    void register_disposer(const std::string& bb_id, const std::string& disposer_symbol);
+
 private:
 
     Halide::Pipeline build(ion::PortMap& ports);
@@ -108,6 +116,7 @@ private:
     std::unique_ptr<Halide::JITUserContext> jit_ctx_;
     Halide::JITUserContext* jit_ctx_ptr_;
     std::vector<const void*> args_;
+    std::vector<std::tuple<std::string, std::function<void(const char*)>>> disposers_;
 };
 
 } // namespace ion

--- a/include/ion/building_block.h
+++ b/include/ion/building_block.h
@@ -4,13 +4,9 @@
 #include <vector>
 #include <Halide.h>
 
-// #include "generator.h"
+#include "builder.h"
 
 namespace ion {
-
-template<typename T>
-class  BuildingBlock : public Halide::Generator<T> {
-};
 
 template<typename T>
 using GeneratorParam = Halide::GeneratorParam<T>;
@@ -29,6 +25,28 @@ using Input = Halide::GeneratorInput<T>;
 
 template<typename T>
 using Output = Halide::GeneratorOutput<T>;
+
+template<typename T>
+class BuildingBlock : public Halide::Generator<T> {
+
+    GeneratorParam<uint64_t> builder_ptr{"builder_ptr", 0};
+    GeneratorParam<std::string> bb_id{"bb_id", ""};
+
+ protected:
+
+     template<typename... Ts>
+     void register_disposer(const std::string& n) {
+         reinterpret_cast<Builder*>(static_cast<uint64_t>(builder_ptr))->register_disposer(bb_id, n);
+     }
+
+     Halide::Buffer<uint8_t> get_id() {
+         std::string bb_id_s(bb_id);
+         Buffer<uint8_t> buf(bb_id_s.size() + 1);
+         buf.fill(0);
+         std::memcpy(buf.data(), bb_id_s.c_str(), bb_id_s.size());
+         return buf;
+     }
+};
 
 } // namespace ion
 

--- a/src/bb/CMakeLists.txt
+++ b/src/bb/CMakeLists.txt
@@ -33,11 +33,10 @@ add_library(ion-bb SHARED bb.cc)
 target_include_directories(ion-bb PUBLIC ${PROJECT_SOURCE_DIR}/include ${PROJECT_SOURCE_DIR}/src ${CMAKE_CURRENT_SOURCE_DIR} ${ION_BB_INCLUDE_DIRS})
 target_link_libraries(ion-bb PUBLIC ion-core ${ION_BB_LIBRARIES})
 if(UNIX)
-    target_compile_options(ion-bb
-        PUBLIC -fno-rtti  # For Halide::Generator
-        PUBLIC -rdynamic) # For JIT compiling
+    target_compile_options(ion-bb PUBLIC -fno-rtti)  # For Halide::Generator
+    target_link_options(ion-bb PUBLIC -Wl,--export-dynamic) # For JIT compiling
 elseif(MSVC)
-    target_compile_options(ion-bb 
+    target_compile_options(ion-bb
         PUBLIC /bigobj)
 endif()
 

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -137,7 +137,7 @@ class U3V {
 
     using arv_shutdown_t = void(*)(void);
 
-    typedef struct {
+    struct DeviceInfo {
         const char* dev_id_;
         ArvDevice* device_;
 
@@ -162,7 +162,7 @@ class U3V {
         bool is_data_image_;
 
         rawHeader header_info_;
-    } DeviceInfo;
+    };
 
     public:
     ~U3V(){
@@ -317,7 +317,7 @@ class U3V {
                         devices_[i].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                             : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
-                        i == 0 ? 
+                        i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
                         arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
@@ -336,7 +336,7 @@ class U3V {
                 devices_[i].frame_count_ = is_gendc_
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                     : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
-                i == 0 ? 
+                i == 0 ?
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
             }
@@ -376,7 +376,7 @@ class U3V {
                                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                                 : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
 
-                            i == 0 ? 
+                            i == 0 ?
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
                         }
@@ -384,7 +384,7 @@ class U3V {
                 }
             }
 
-            for (int i = 0; i < num_sensor_; ++i){ 
+            for (int i = 0; i < num_sensor_; ++i){
                 ::memcpy(outs[i], arv_buffer_get_part_data(bufs[i], 0, nullptr), devices_[i].image_payload_size_);
                 arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
                 log::trace("Obtained Frame from USB{}: {}", i, devices_[i].frame_count_);
@@ -405,7 +405,7 @@ class U3V {
                 // if all stream has N output buffers, discard N-1 of them
                 for(auto i = 0; i < num_device; ++i){
                     for (auto j = 0; j < N_output_buffers[i]-1; ++j){
-                        
+
                         bufs[i] = arv_stream_timeout_pop_buffer (devices_[i].stream_, timeout_us);
                         if (bufs[i] == nullptr){
                             log::error("pop_buffer(L11) failed due to timeout ({}s)", timeout_us*1e-6f);
@@ -414,7 +414,7 @@ class U3V {
                         devices_[i].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                             : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
-                        i == 0 ? 
+                        i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
                         arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
@@ -422,7 +422,7 @@ class U3V {
                 }
             }
 
-            //first buffer 
+            //first buffer
             cameN_idx_ = (cameN_idx_+1) >= num_device ? 0 : cameN_idx_+1;
             bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, 30 * 1000 * 1000);
             if (bufs[cameN_idx_] == nullptr){
@@ -433,12 +433,12 @@ class U3V {
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
                     : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
             latest_cnt = devices_[cameN_idx_].frame_count_;
-            cameN_idx_ == 0 ?    
+            cameN_idx_ == 0 ?
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
 
             int internal_count = 0;
-            int max_internal_count = 1000;            
+            int max_internal_count = 1000;
 
             while (frame_cnt_ >= latest_cnt) {
                 arv_stream_push_buffer(devices_[cameN_idx_].stream_, bufs[cameN_idx_]);
@@ -452,7 +452,7 @@ class U3V {
                         : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
                 latest_cnt = devices_[cameN_idx_].frame_count_;
 
-                cameN_idx_ == 0 ? 
+                cameN_idx_ == 0 ?
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
 
@@ -498,7 +498,7 @@ class U3V {
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                             : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
 
-                        i == 0 ? 
+                        i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
                         arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
@@ -518,7 +518,7 @@ class U3V {
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                     : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
 
-                i == 0 ? 
+                i == 0 ?
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
             }
@@ -556,7 +556,7 @@ class U3V {
                             devices_[i].frame_count_ = is_gendc_
                                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                                 : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
-                            i == 0 ? 
+                            i == 0 ?
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
                         }
@@ -584,7 +584,7 @@ class U3V {
                 // if all stream has N output buffers, discard N-1 of them
                 for(auto i = 0; i < num_device; ++i){
                     for (auto j = 0; j < N_output_buffers[i]-1; ++j){
-                        
+
                         bufs[i] = arv_stream_timeout_pop_buffer (devices_[i].stream_, timeout_us);
                         if (bufs[i] == nullptr){
                             log::error("pop_buffer(L12) failed due to timeout ({}s)", timeout_us*1e-6f);
@@ -593,7 +593,7 @@ class U3V {
                         devices_[i].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
                             : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
-                        i == 0 ? 
+                        i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
                         arv_stream_push_buffer(devices_[i].stream_, bufs[i]);
@@ -601,7 +601,7 @@ class U3V {
                 }
             }
 
-            //first buffer 
+            //first buffer
             cameN_idx_ = (cameN_idx_+1) >= num_device ? 0 : cameN_idx_+1;
             bufs[cameN_idx_] = arv_stream_timeout_pop_buffer (devices_[cameN_idx_].stream_, 30 * 1000 * 1000);
             if (bufs[cameN_idx_] == nullptr){
@@ -612,7 +612,7 @@ class U3V {
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
                     : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
             latest_cnt = devices_[cameN_idx_].frame_count_;
-            cameN_idx_ == 0 ?    
+            cameN_idx_ == 0 ?
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
 
@@ -630,7 +630,7 @@ class U3V {
                     devices_[cameN_idx_].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
                             : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
-                    cameN_idx_ == 0 ? 
+                    cameN_idx_ == 0 ?
                         log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
                         log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
                     latest_cnt = devices_[cameN_idx_].frame_count_;
@@ -1108,7 +1108,7 @@ class U3V {
 std::unique_ptr<U3V> U3V::instance_;
 
 int u3v_camera_frame_count(
-    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode, 
+    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode,
     halide_buffer_t* out)
 {
     try {
@@ -1134,7 +1134,7 @@ int u3v_camera_frame_count(
         return 1;
     }
 }
-  
+
 }  // namespace image_io
 }  // namespace bb
 }  // namespace ion
@@ -1213,7 +1213,7 @@ ION_REGISTER_EXTERN(ion_bb_image_io_u3v_camera2);
 extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_camera1_frame_count(
     halide_buffer_t *,
-    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode, 
+    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode,
     halide_buffer_t* out)
 {
     return ion::bb::image_io::u3v_camera_frame_count(dispose, num_sensor, frame_sync, realtime_display_mode, out);
@@ -1224,7 +1224,7 @@ extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_camera2_frame_count(
     halide_buffer_t *,
     halide_buffer_t *,
-    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode, 
+    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode,
     halide_buffer_t* out)
 {
     return ion::bb::image_io::u3v_camera_frame_count(dispose, num_sensor, frame_sync, realtime_display_mode, out);
@@ -1489,7 +1489,7 @@ ION_REGISTER_EXTERN(ion_bb_image_io_u3v_multiple_camera2);
 
 extern "C"
 int ION_EXPORT ion_bb_image_io_u3v_multiple_camera_frame_count1(
-    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode, 
+    bool dispose, int32_t num_sensor, bool frame_sync, bool realtime_display_mode,
     halide_buffer_t* out)
 {
     return ion::bb::image_io::u3v_camera_frame_count(dispose, num_sensor, frame_sync, realtime_display_mode, out);

--- a/src/dynamic_module.h
+++ b/src/dynamic_module.h
@@ -69,6 +69,7 @@ class DynamicModule {
 #endif
     }
 
+
  private:
 
      std::string getErrorString(void) const {

--- a/src/log.cc
+++ b/src/log.cc
@@ -1,3 +1,6 @@
+#ifndef FMT_CONSTEVAL
+#define FMT_CONSTEVAL // To prevent format string is evaluated as constexpr
+#endif
 #include "spdlog/cfg/helpers.h"
 #include "spdlog/details/os.h"
 #include "spdlog/sinks/stdout_color_sinks.h"

--- a/src/log.h
+++ b/src/log.h
@@ -1,17 +1,22 @@
 #ifndef ION_LOG_H
 #define ION_LOG_H
 
+#ifndef FMT_CONSTEVAL
+#define FMT_CONSTEVAL // To prevent format string is evaluated as constexpr
+#endif
 #include "spdlog/spdlog.h"
 
 namespace ion {
 namespace log {
+
 std::shared_ptr<spdlog::logger> get();
-template<class... Types> static void critical(Types... args) { get()->critical(args...); }
-template<class... Types> static void error   (Types... args) { get()->error   (args...); }
-template<class... Types> static void warn    (Types... args) { get()->warn    (args...); }
-template<class... Types> static void info    (Types... args) { get()->info    (args...); }
-template<class... Types> static void debug   (Types... args) { get()->debug   (args...); }
-template<class... Types> static void trace   (Types... args) { get()->trace   (args...); }
+
+template<typename... Args> inline void critical(Args... args) { get()->critical(args...); }
+template<typename... Args> inline void error   (Args... args) { get()->error   (args...); }
+template<typename... Args> inline void warn    (Args... args) { get()->warn    (args...); }
+template<typename... Args> inline void info    (Args... args) { get()->info    (args...); }
+template<typename... Args> inline void debug   (Args... args) { get()->debug   (args...); }
+template<typename... Args> inline void trace   (Args... args) { get()->trace   (args...); }
 } // log
 } // ion
 

--- a/test/simple_graph_jit.cc
+++ b/test/simple_graph_jit.cc
@@ -9,7 +9,7 @@ int main()
     Param v41{"v", "41"};
     Builder b;
     b.with_bb_module("ion-bb-test");
-    b.set_target(Halide::get_host_target().with_feature(Halide::Target::Debug).with_feature(Halide::Target::TracePipeline));
+    b.set_target(Halide::get_host_target());
     Node n;
     n = b.add("test_producer").set_param(v41);
     n = b.add("test_consumer")(n["output"], min0, extent0, min1, extent1, v);
@@ -24,7 +24,10 @@ int main()
     ion::Buffer<int32_t> r = ion::Buffer<int32_t>::make_scalar();
     pm.set(n["output"], r);
 
-    b.run(pm);
+    for (int i=0; i<5; ++i) {
+        std::cout << i << "'th loop" << std::endl;
+        b.run(pm);
+    }
 
     return 0;
 }

--- a/test/test-bb.h
+++ b/test/test-bb.h
@@ -38,11 +38,13 @@ public:
         Func in;
         in(x, y) = input(x, y);
         in.compute_root();
-        std::vector<ExternFuncArgument> params{in, desired_min0, desired_extent0, desired_min1, desired_extent1, v};
+        std::vector<ExternFuncArgument> params{in, get_id(), desired_min0, desired_extent0, desired_min1, desired_extent1, v};
         Func consume;
         consume.define_extern("consume", params, Int(32), 0);
         consume.compute_root();
         output() = consume();
+
+        register_disposer("consume_dispose");
     }
 
     void schedule() {

--- a/test/test-rt.h
+++ b/test/test-rt.h
@@ -112,13 +112,20 @@ private:
 };
 
 extern "C" DLLEXPORT
-int consume(halide_buffer_t *in, int desired_min0, int desired_extent0, int desired_min1, int desired_extent1, int32_t v, halide_buffer_t *out) {
+int consume_dispose(const char *id) {
+    ion::log::info("consume_dispose is called with id={}", id);
+    return 0;
+}
+
+extern "C" DLLEXPORT
+int consume(halide_buffer_t *in, halide_buffer_t *id_buf, int desired_min0, int desired_extent0, int desired_min1, int desired_extent1, int32_t v, halide_buffer_t *out) {
     if (in->is_bounds_query()) {
         in->dim[0].min = desired_min0;
         in->dim[0].extent = desired_extent0;
         in->dim[1].min = desired_min1;
         in->dim[1].extent = desired_extent1;
     } else {
+        ion::log::info("consume is called with id={}", reinterpret_cast<const char*>(id_buf->host));
         Halide::Runtime::Buffer<int32_t> ibuf(*in);
         for (int y=0; y<in->dim[1].extent; ++y) {
             for (int x=0; x<in->dim[0].extent; ++x) {


### PR DESCRIPTION
- Introduced BuildingBlock::register_disposer 
- register_disposer takes the symbol name for the dispose function which is defined in rt.h
- The dispose function will take one argument (const char *id) which is tied with the building block instance. `id` value is always identical with ion::Node::id().