### PR TITLE
Fix/python package link

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,7 +26,7 @@ elseif(UNIX)
 endif()
 
 
-# Dependent librariesgit
+# Dependent libraries
 #
 # NOTE: WIP: It's for static linking
 # set(ZLIB_USE_STATIC_LIBS "ON")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,9 +19,14 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON) # This is required to export symbols on windows platform
 set(CMAKE_MODULE_PATH "${PROJECT_SOURCE_DIR}/cmake" ${CMAKE_MODULE_PATH})
 
+if(APPLE)
+    set(CMAKE_INSTALL_RPATH "@loader_path")
+elseif(UNIX)
+    set(CMAKE_INSTALL_RPATH "$ORIGIN")
+endif()
 
-#
-# Dependent libraries
+
+# Dependent librariesgit
 #
 # NOTE: WIP: It's for static linking
 # set(ZLIB_USE_STATIC_LIBS "ON")

--- a/python/ionpy/module/linux/README.md
+++ b/python/ionpy/module/linux/README.md
@@ -3,6 +3,6 @@ Please include 3 .so libraries in this directory if you are using linux.
 linux
 ├──libion-core.so
 ├──libion-bb.so
-├──libHalide.so.16.0.0
+├──libHalide.so.16
 └── README.md
 ```

--- a/python/ionpy/module/macos/README.md
+++ b/python/ionpy/module/macos/README.md
@@ -3,6 +3,6 @@ Please include 3 .dylib libraries in this directory if you are using macos.
 macos
 ├──libion-core.dylib
 ├──libion-bb.dylib
-├──libHalide.16.0.0.dylib
+├──libHalide.16.dylib
 └── README.md
 ```


### PR DESCRIPTION
1. add rpath  on mac and linux when compile and build ion-core and libion-bb

$ readelf -d libion-bb.so
 
```
Dynamic section at offset 0x62b258 contains 34 entries:
  Tag        Type                         Name/Value
 0x000000000000001d (RUNPATH)            Library runpath: [$ORIGIN]
```

