### PR TITLE
corrected the name of dependencies on vcpkg

### DIFF
--- a/BUILD-Linux.md
+++ b/BUILD-Linux.md
@@ -15,10 +15,10 @@ For Halide, please find latest binary release [here](https://github.com/halide/H
 curl -sL https://github.com/halide/Halide/releases/download/v16.0.0/Halide-16.0.0-x86-64-linux-1e963ff817ef0968cc25d811a25a7350c8953ee6.tar.gz | tar zx
 ```
 
-We recommend to setup libjpeg, libpng and zlib by [vcpkg](https://vcpkg.io/).
+We recommend to setup libjpeg-turbo, libpng and zlib by [vcpkg](https://vcpkg.io/).
 
 ```sh
-vcpkg install libjpeg libpng zlib
+vcpkg install libjpeg-turbo libpng zlib
 ```
 
 ## 2. Build

--- a/BUILD-Windows.md
+++ b/BUILD-Windows.md
@@ -11,10 +11,10 @@ Here is the list of dependent software.
 
 For Halide, please find latest binary release [here](https://github.com/halide/Halide/releases) and extract it.
 
-We recommend to setup libjpeg, libpng and zlib by [vcpkg](https://vcpkg.io/).
+We recommend to setup libjpeg-turbo, libpng and zlib by [vcpkg](https://vcpkg.io/).
 
 ```sh
-vcpkg install libjpeg:x64-windows-static libpng:x64-windows-static zlib:x64-windows-static
+vcpkg install libjpeg-turbo:x64-windows-static libpng:x64-windows-static zlib:x64-windows-static
 ```
 
 ## 2. Build


### PR DESCRIPTION
For Windows and Linux build instruction, the name of dependency-packages on vcpkg is `libjpeg-turbo` instead of `libjpeg`