### PR TITLE
Return -1 for devices has no frame count

### DIFF
--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -130,6 +130,7 @@ class U3V {
     using arv_buffer_get_data_t = void*(*)(ArvBuffer*, size_t*);
     using arv_buffer_get_part_data_t = void*(*)(ArvBuffer*, uint_fast32_t, size_t*);
     using arv_buffer_get_timestamp_t = uint64_t(*)(ArvBuffer*);
+    using arv_buffer_get_frame_id_t = uint64_t(*)(ArvBuffer*);
     using arv_device_get_feature_t = ArvGcNode*(*)(ArvDevice*, const char*);
 
     using arv_buffer_has_gendc_t = bool*(*)(ArvBuffer*);
@@ -334,7 +335,7 @@ class U3V {
                         }
                         devices_[i].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
@@ -353,7 +354,7 @@ class U3V {
                 }
                 devices_[i].frame_count_ = is_gendc_
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                    : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                    : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
                 i == 0 ?
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
@@ -392,7 +393,7 @@ class U3V {
                             }
                             devices_[i].frame_count_ = is_gendc_
                                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                                : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
 
                             i == 0 ?
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
@@ -432,7 +433,7 @@ class U3V {
                         }
                         devices_[i].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
@@ -449,8 +450,8 @@ class U3V {
                 throw ::std::runtime_error("buffer is null");
             }
             devices_[cameN_idx_].frame_count_ = is_gendc_
-                    ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                    : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
+                ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
+                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
             latest_cnt = devices_[cameN_idx_].frame_count_;
             cameN_idx_ == 0 ?
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
@@ -467,8 +468,8 @@ class U3V {
                     throw ::std::runtime_error("buffer is null");
                 }
                 devices_[cameN_idx_].frame_count_ = is_gendc_
-                        ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                        : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
+                    ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
+                    : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
                 latest_cnt = devices_[cameN_idx_].frame_count_;
 
                 cameN_idx_ == 0 ?
@@ -516,7 +517,7 @@ class U3V {
                         }
                         devices_[i].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
 
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
@@ -536,7 +537,7 @@ class U3V {
                 }
                 devices_[i].frame_count_ = is_gendc_
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                    : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                    : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
 
                 i == 0 ?
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
@@ -575,7 +576,7 @@ class U3V {
                             }
                             devices_[i].frame_count_ = is_gendc_
                                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                                : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
                             i == 0 ?
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
@@ -612,7 +613,7 @@ class U3V {
                         }
                         devices_[i].frame_count_ = is_gendc_
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF);
+                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
@@ -629,8 +630,8 @@ class U3V {
                 throw ::std::runtime_error("buffer is null");
             }
             devices_[cameN_idx_].frame_count_ = is_gendc_
-                    ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                    : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
+                ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
+                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
             latest_cnt = devices_[cameN_idx_].frame_count_;
             cameN_idx_ == 0 ?
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
@@ -648,8 +649,8 @@ class U3V {
                             throw ::std::runtime_error("buffer is null");
                     }
                     devices_[cameN_idx_].frame_count_ = is_gendc_
-                            ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                            : static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF);
+                        ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
+                        : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
                     cameN_idx_ == 0 ?
                         log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
                         log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
@@ -684,7 +685,7 @@ class U3V {
     U3V(int32_t num_sensor, bool frame_sync, bool realtime_display_mode, char* dev_id = nullptr)
     : gobject_(GOBJECT_FILE, true), aravis_(ARAVIS_FILE, true),
         num_sensor_(num_sensor),
-        frame_sync_(frame_sync), realtime_display_mode_(realtime_display_mode), is_gendc_(false), is_param_integer_(false),
+        frame_sync_(frame_sync), realtime_display_mode_(realtime_display_mode), is_gendc_(false), is_param_integer_(false), is_timestamp_framecount_(false),
         devices_(num_sensor), buffers_(num_sensor), operation_mode_(OperationMode::Came1USB1), frame_cnt_(0), cameN_idx_(-1), disposed_(false)
     {
         init_symbols();
@@ -747,6 +748,7 @@ class U3V {
                 device_model_name = arv_device_get_string_feature_value(devices_[i].device_, "DeviceModelName", &err_);
                 if (strcmp(device_model_name, "    ")==0){
                     is_param_integer_ = true;
+                    is_timestamp_framecount_ = true;
                 }
             }
 
@@ -972,6 +974,7 @@ class U3V {
         GET_SYMBOL(arv_buffer_get_data, "arv_buffer_get_data");
         GET_SYMBOL(arv_buffer_get_part_data, "arv_buffer_get_part_data");
         GET_SYMBOL(arv_buffer_get_timestamp, "arv_buffer_get_timestamp");
+        GET_SYMBOL(arv_buffer_get_frame_id , "arv_buffer_get_frame_id");
         GET_SYMBOL(arv_device_get_feature, "arv_device_get_feature");
 
         GET_SYMBOL(arv_buffer_has_gendc, "arv_buffer_has_gendc");
@@ -1081,6 +1084,7 @@ class U3V {
     arv_buffer_get_data_t arv_buffer_get_data;
     arv_buffer_get_part_data_t arv_buffer_get_part_data;
     arv_buffer_get_timestamp_t arv_buffer_get_timestamp;
+    arv_buffer_get_frame_id_t arv_buffer_get_frame_id;
     arv_device_get_feature_t arv_device_get_feature;
 
     arv_buffer_has_gendc_t arv_buffer_has_gendc;
@@ -1101,6 +1105,7 @@ class U3V {
     bool realtime_display_mode_;
     bool is_gendc_;
     bool is_param_integer_;
+    bool is_timestamp_framecount_;
     int32_t operation_mode_;
 
     uint32_t frame_cnt_;

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -41,6 +41,12 @@ class U3V {
         Came1USB2
     };
 
+    enum FrameCountMethod {
+        UNAVAILABLE = -1,
+        TIMESTAMP = 0,
+        TYPESPECIFIC3 = 1
+    };
+
     using gpointer = struct gpointer_*;
 
     using g_object_unref_t = void (*)(gpointer);
@@ -159,7 +165,7 @@ class U3V {
         // genDC
         int64_t data_offset_;
         std::tuple<int32_t, int32_t> available_comp_part;
-        int32_t framecount_offset_;
+        int32_t framecount_offset_ = -1;
         bool is_data_image_;
 
         rawHeader header_info_;
@@ -333,9 +339,11 @@ class U3V {
                             log::error("pop_buffer(L2) failed due to timeout ({}s)", timeout_us*1e-6f);
                             throw ::std::runtime_error("buffer is null");
                         }
-                        devices_[i].frame_count_ = is_gendc_
+                        devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
+                            : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                            ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                            : -1;
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
@@ -352,9 +360,11 @@ class U3V {
                     log::error("pop_buffer(L1) failed due to timeout ({}s)", timeout_us*1e-6f);
                     throw ::std::runtime_error("Buffer is null");
                 }
-                devices_[i].frame_count_ = is_gendc_
+                devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                    : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
+                    : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                    ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                    : -1;
                 i == 0 ?
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
@@ -391,10 +401,11 @@ class U3V {
                                 log::error("pop_buffer(L3) failed due to timeout ({}s)", timeout_us*1e-6f);
                                 throw ::std::runtime_error("buffer is null");
                             }
-                            devices_[i].frame_count_ = is_gendc_
+                            devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
-
+                                : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                                ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                                : -1;
                             i == 0 ?
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
@@ -431,9 +442,11 @@ class U3V {
                             log::error("pop_buffer(L11) failed due to timeout ({}s)", timeout_us*1e-6f);
                             throw ::std::runtime_error("buffer is null");
                         }
-                        devices_[i].frame_count_ = is_gendc_
+                        devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
+                            : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                            ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                            : -1;
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
@@ -449,9 +462,11 @@ class U3V {
                 log::error("pop_buffer(L4) failed due to timeout ({}s)", timeout_us*1e-6f);
                 throw ::std::runtime_error("buffer is null");
             }
-            devices_[cameN_idx_].frame_count_ = is_gendc_
+            devices_[cameN_idx_].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
+                : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) 
+                : -1;
             latest_cnt = devices_[cameN_idx_].frame_count_;
             cameN_idx_ == 0 ?
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
@@ -467,9 +482,11 @@ class U3V {
                     log::error("pop_buffer(L4) failed due to timeout ({}s)", timeout_us*1e-6f);
                     throw ::std::runtime_error("buffer is null");
                 }
-                devices_[cameN_idx_].frame_count_ = is_gendc_
+                devices_[cameN_idx_].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                    : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
+                    : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                    ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) 
+                    : -1;
                 latest_cnt = devices_[cameN_idx_].frame_count_;
 
                 cameN_idx_ == 0 ?
@@ -515,10 +532,11 @@ class U3V {
                             log::error("pop_buffer(L6) failed due to timeout ({}s)", timeout_us*1e-6f);
                             throw ::std::runtime_error("buffer is null");
                         }
-                        devices_[i].frame_count_ = is_gendc_
+                        devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
-
+                            : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                            ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                            : -1;
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
@@ -535,9 +553,11 @@ class U3V {
                     log::error("pop_buffer(L5) failed due to timeout ({}s)", timeout_us*1e-6f);
                     throw ::std::runtime_error("buffer is null");
                 }
-                devices_[i].frame_count_ = is_gendc_
+                devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                     ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                    : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
+                    : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                    ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                    : -1;
 
                 i == 0 ?
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
@@ -574,9 +594,11 @@ class U3V {
                                 log::error("pop_buffer(L7) failed due to timeout ({}s)", timeout_us*1e-6f);
                                 throw ::std::runtime_error("buffer is null");
                             }
-                            devices_[i].frame_count_ = is_gendc_
+                            devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
+                                : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                                ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                                : -1;
                             i == 0 ?
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[i].frame_count_, "") :
                                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[i].frame_count_);
@@ -611,9 +633,11 @@ class U3V {
                             log::error("pop_buffer(L12) failed due to timeout ({}s)", timeout_us*1e-6f);
                             throw ::std::runtime_error("buffer is null");
                         }
-                        devices_[i].frame_count_ = is_gendc_
+                        devices_[i].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                             ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[i], devices_[i]))
-                            : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[i]));
+                            : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                            ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[i]) & 0x00000000FFFFFFFF) 
+                            : -1;
                         i == 0 ?
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", devices_[i].frame_count_, "") :
                             log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20}) [skipped for realtime display]", "", devices_[i].frame_count_);
@@ -629,9 +653,11 @@ class U3V {
                 log::error("pop_buffer(L4) failed due to timeout ({}s)", timeout_us*1e-6f);
                 throw ::std::runtime_error("buffer is null");
             }
-            devices_[cameN_idx_].frame_count_ = is_gendc_
+            devices_[cameN_idx_].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
                 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
+                : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) 
+                : -1;
             latest_cnt = devices_[cameN_idx_].frame_count_;
             cameN_idx_ == 0 ?
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
@@ -648,9 +674,12 @@ class U3V {
                         log::error("pop_buffer(L8) failed due to timeout ({}s)", timeout2_us*1e-6f);
                             throw ::std::runtime_error("buffer is null");
                     }
-                    devices_[cameN_idx_].frame_count_ = is_gendc_
-                        ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
-                        : is_timestamp_framecount_ ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) : static_cast<uint32_t>(arv_buffer_get_frame_id(bufs[cameN_idx_]));
+            devices_[cameN_idx_].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
+                ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[cameN_idx_], devices_[cameN_idx_]))
+                : frame_count_method_ == FrameCountMethod::TIMESTAMP 
+                ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[cameN_idx_]) & 0x00000000FFFFFFFF) 
+                : -1;
+                        
                     cameN_idx_ == 0 ?
                         log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[cameN_idx_].frame_count_, "") :
                         log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[cameN_idx_].frame_count_);
@@ -685,7 +714,7 @@ class U3V {
     U3V(int32_t num_sensor, bool frame_sync, bool realtime_display_mode, char* dev_id = nullptr)
     : gobject_(GOBJECT_FILE, true), aravis_(ARAVIS_FILE, true),
         num_sensor_(num_sensor),
-        frame_sync_(frame_sync), realtime_display_mode_(realtime_display_mode), is_gendc_(false), is_param_integer_(false), is_timestamp_framecount_(false),
+        frame_sync_(frame_sync), realtime_display_mode_(realtime_display_mode), is_gendc_(false), is_param_integer_(false), frame_count_method_(FrameCountMethod::UNAVAILABLE),
         devices_(num_sensor), buffers_(num_sensor), operation_mode_(OperationMode::Came1USB1), frame_cnt_(0), cameN_idx_(-1), disposed_(false)
     {
         init_symbols();
@@ -740,18 +769,6 @@ class U3V {
             }
             log::info("\tDevice/USB {}::{} : {}", i, "PixelFormat", pixel_format_);
 
-            // Some type of U3V Camera has integer type on gain and exposure
-            const char* device_vender_name;
-            device_vender_name = arv_device_get_string_feature_value(devices_[i].device_, "DeviceVendorName", &err_);
-            if (strcmp(device_vender_name, "Sony Semiconductor Solutions Corporation")==0){
-                const char* device_model_name;
-                device_model_name = arv_device_get_string_feature_value(devices_[i].device_, "DeviceModelName", &err_);
-                if (strcmp(device_model_name, "    ")==0){
-                    is_param_integer_ = true;
-                    is_timestamp_framecount_ = true;
-                }
-            }
-
             // Here PayloadSize is the one for U3V data
             devices_[i].u3v_payload_size_ = arv_device_get_integer_feature_value(devices_[i].device_, "PayloadSize", &err_);
             log::info("\tDevice/USB {}::{} : {}", i, "PayloadSize", devices_[i].u3v_payload_size_);
@@ -787,6 +804,25 @@ class U3V {
                 is_gendc_ &= (strcmp(streaming_mode, "On")==0);
             }
 
+            // Some type of U3V Camera has integer type on gain and exposure
+            // Some type of U3V Camera supports Frame count generated by its device
+            const char* device_vender_name;
+            device_vender_name = arv_device_get_string_feature_value(devices_[i].device_, "DeviceVendorName", &err_);
+            if (strcmp(device_vender_name, "Sony Semiconductor Solutions Corporation")==0){
+                const char* device_model_name;
+                device_model_name = arv_device_get_string_feature_value(devices_[i].device_, "DeviceModelName", &err_);
+                if (strcmp(device_model_name, "    ")==0){
+                    is_param_integer_ = true;
+                    frame_count_method_ = FrameCountMethod::TIMESTAMP;
+                }
+                if (is_gendc_){
+                    frame_count_method_ = FrameCountMethod::TYPESPECIFIC3;
+                }
+            }
+            log::info("\tDevice/USB {}::{} : {}", i, "frame_count method is ", 
+                frame_count_method_ == FrameCountMethod::TIMESTAMP ? "Timestamp" 
+                : frame_count_method_ == FrameCountMethod::TYPESPECIFIC3 ? "TypeSpecific" : "Unavailabe");
+
             // Check each parameters for GenDC device ==========================
             if (is_gendc_){
                 log::info("\tDevice/USB {}::{} : {}", i, "GenDC", "Available");
@@ -815,7 +851,9 @@ class U3V {
                     }
                     devices_[i].data_offset_ = gendc_descriptor_.getDataOffset(std::get<0>(data_comp_and_part), std::get<1>(data_comp_and_part));
                     devices_[i].image_payload_size_ = gendc_descriptor_.getDataSize(std::get<0>(data_comp_and_part), std::get<1>(data_comp_and_part));
-                    devices_[i].framecount_offset_ = gendc_descriptor_.getOffsetFromTypeSpecific(std::get<0>(data_comp_and_part), std::get<1>(data_comp_and_part), 3, 0);
+                    if (frame_count_method_ == FrameCountMethod::TYPESPECIFIC3){
+                        devices_[i].framecount_offset_ = gendc_descriptor_.getOffsetFromTypeSpecific(std::get<0>(data_comp_and_part), std::get<1>(data_comp_and_part), 3, 0);
+                    }
                 }
                 free(buffer);
             }else{
@@ -1105,7 +1143,10 @@ class U3V {
     bool realtime_display_mode_;
     bool is_gendc_;
     bool is_param_integer_;
-    bool is_timestamp_framecount_;
+
+    int frame_count_method_;
+
+
     int32_t operation_mode_;
 
     uint32_t frame_cnt_;


### PR DESCRIPTION
With Basler, `arv_buffer_get_frame_id` obtained blockid of U3V leader, which starts at 0 and increments by 1 for each frame.

The log with frame number:

```
[2024-03-01 16:09:50.531] [ion] [info] Start building pipeline
[2024-03-01 16:09:50.532] [ion] [debug] Determine free port _ion_iport_0 as input_images on Node 7ba02f55-2d1e-4b2a-b0f9-7a0287f13d00
[2024-03-01 16:09:50.532] [ion] [debug] Determine free port _ion_iport_1 as input_deviceinfo on Node 7ba02f55-2d1e-4b2a-b0f9-7a0287f13d00
[2024-03-01 16:09:50.532] [ion] [debug] Determine free port _ion_iport_2 as frame_count on Node 7ba02f55-2d1e-4b2a-b0f9-7a0287f13d00
[2024-03-01 16:09:50.533] [ion] [debug] Determine free port _ion_iport_3 as width on Node 7ba02f55-2d1e-4b2a-b0f9-7a0287f13d00
[2024-03-01 16:09:50.533] [ion] [debug] Determine free port _ion_iport_4 as height on Node 7ba02f55-2d1e-4b2a-b0f9-7a0287f13d00
[2024-03-01 16:09:50.533] [ion] [info] Builder::register_disposer
[2024-03-01 16:09:50.533] [ion] [info] Builder::register_disposer
[2024-03-01 16:09:51.146] [ion] [info] Create U3V instance: 730dcfcc-9666-4dea-ba6d-ba327571bab3
[2024-03-01 16:09:51.146] [ion] [debug] U3V:: 23-11-18 : updating obtain and write
[2024-03-01 16:09:51.147] [ion] [info] Using aravis-0.8.31
[2024-03-01 16:09:52.172] [ion] [info] Creating U3V instance with 1 devices...
[2024-03-01 16:09:52.173] [ion] [info] Acquisition option::frame_sync_ is false
[2024-03-01 16:09:52.175] [ion] [info] Acquisition option::realtime_display_mode_ is false
[2024-03-01 16:09:52.176] [ion] [info]  Device/USB 0::DeviceID : Basler-26760158A14A-22585674
[2024-03-01 16:09:52.245] [ion] [info]  Device/USB 0::PixelFormat : RGB8
[2024-03-01 16:09:52.247] [ion] [info]  Device/USB 0::PayloadSize : 3686400
[2024-03-01 16:09:52.249] [ion] [info]  Device/USB 0::GenDC : Not Supported
[2024-03-01 16:09:52.250] [ion] [info]  Device/USB 0::Width : 1280
[2024-03-01 16:09:52.250] [ion] [info]  Device/USB 0::Height : 960
[2024-03-01 16:09:52.252] [ion] [info]  Device/USB 0::Buffer Size : 1073741824
[2024-03-01 16:09:52.252] [ion] [info]  Device/USB 0::Number of Buffers : 292
[2024-03-01 16:09:52.252] [ion] [info]  Device/USB 0::Command : AcquisitionMode
[2024-03-01 16:09:52.257] [ion] [info]  Device/USB 0::Command : AcquisitionStart
[2024-03-01 16:09:52.293] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   0,                     )
[2024-03-01 16:09:52.294] [ion] [trace] Obtained Frame from USB0: 0
[2024-03-01 16:09:52.295] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.316] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   1,                     )
[2024-03-01 16:09:52.320] [ion] [trace] Obtained Frame from USB0: 1
[2024-03-01 16:09:52.322] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.339] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   2,                     )
[2024-03-01 16:09:52.341] [ion] [trace] Obtained Frame from USB0: 2
[2024-03-01 16:09:52.342] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.362] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   3,                     )
[2024-03-01 16:09:52.364] [ion] [trace] Obtained Frame from USB0: 3
[2024-03-01 16:09:52.364] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.385] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   4,                     )
[2024-03-01 16:09:52.387] [ion] [trace] Obtained Frame from USB0: 4
[2024-03-01 16:09:52.387] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.409] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   5,                     )
[2024-03-01 16:09:52.410] [ion] [trace] Obtained Frame from USB0: 5
[2024-03-01 16:09:52.410] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.432] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   6,                     )
[2024-03-01 16:09:52.433] [ion] [trace] Obtained Frame from USB0: 6
[2024-03-01 16:09:52.434] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.455] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   7,                     )
[2024-03-01 16:09:52.456] [ion] [trace] Obtained Frame from USB0: 7
[2024-03-01 16:09:52.457] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.478] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   8,                     )
[2024-03-01 16:09:52.479] [ion] [trace] Obtained Frame from USB0: 8
[2024-03-01 16:09:52.480] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.501] [ion] [trace] All-Popped Frames (USB0, USB1)=(                   9,                     )
[2024-03-01 16:09:52.503] [ion] [trace] Obtained Frame from USB0: 9
[2024-03-01 16:09:52.503] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.524] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  10,                     )
[2024-03-01 16:09:52.526] [ion] [trace] Obtained Frame from USB0: 10
[2024-03-01 16:09:52.527] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.548] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  11,                     )
[2024-03-01 16:09:52.549] [ion] [trace] Obtained Frame from USB0: 11
[2024-03-01 16:09:52.550] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.571] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  12,                     )
[2024-03-01 16:09:52.572] [ion] [trace] Obtained Frame from USB0: 12
[2024-03-01 16:09:52.573] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.594] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  13,                     )
[2024-03-01 16:09:52.595] [ion] [trace] Obtained Frame from USB0: 13
[2024-03-01 16:09:52.596] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.617] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  14,                     )
[2024-03-01 16:09:52.621] [ion] [trace] Obtained Frame from USB0: 14
[2024-03-01 16:09:52.622] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.640] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  15,                     )
[2024-03-01 16:09:52.642] [ion] [trace] Obtained Frame from USB0: 15
[2024-03-01 16:09:52.643] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.663] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  16,                     )
[2024-03-01 16:09:52.665] [ion] [trace] Obtained Frame from USB0: 16
[2024-03-01 16:09:52.665] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.687] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  17,                     )
[2024-03-01 16:09:52.688] [ion] [trace] Obtained Frame from USB0: 17
[2024-03-01 16:09:52.689] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.710] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  18,                     )
[2024-03-01 16:09:52.711] [ion] [trace] Obtained Frame from USB0: 18
[2024-03-01 16:09:52.712] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.733] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  19,                     )
[2024-03-01 16:09:52.734] [ion] [trace] Obtained Frame from USB0: 19
[2024-03-01 16:09:52.735] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.756] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  20,                     )
[2024-03-01 16:09:52.758] [ion] [trace] Obtained Frame from USB0: 20
[2024-03-01 16:09:52.758] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.779] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  21,                     )
[2024-03-01 16:09:52.781] [ion] [trace] Obtained Frame from USB0: 21
[2024-03-01 16:09:52.781] [ion] [trace] Obtained Device info USB0
[2024-03-01 16:09:52.803] [ion] [trace] All-Popped Frames (USB0, USB1)=(                  22,                     )
...
```