### PR TITLE
Fix port index access in capi

### DIFF
--- a/src/c_ion.cc
+++ b/src/c_ion.cc
@@ -46,7 +46,6 @@ int ion_port_create_with_index(ion_port_t *ptr, ion_port_t obj, int index)
         auto p = new Port(*reinterpret_cast<Port*>(obj));
         p->set_index(index);
         *ptr = reinterpret_cast<ion_port_t>(p);
-        reinterpret_cast<ion::Port*>(obj)->set_index(index);
     } catch (const Halide::Error& e) {
         log::error(e.what());
         return 1;


### PR DESCRIPTION
```
auto p = new Port(*reinterpret_cast<Port*>(obj)); 
p->set_index(index); 
*ptr = reinterpret_cast<ion_port_t>(p); 
```
~~reinterpret_cast<ion::Port*>(obj)->set_index(index);~~ 

obj doen't need to set_index, otherwise have issue on following example 
p0 = ports[0] (make a copy of ports and set index to 0)
p1 = ports[1]  (make a copy of ports and set index to 1)
when access ports again, the index of ports will be 1 instead of -1 