### PR TITLE
Fix/config json override

### DIFF
--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -212,6 +212,7 @@ public:
     void write_config_file(ion::bb::image_io::rawHeader& header_info){
         nlohmann::json j;
         nlohmann::json j_sensor;
+        j_sensor["prefix"] = prefix_;
         j_sensor["framerate"] = header_info.fps_;
         j_sensor["width"] = header_info.width_;
         j_sensor["height"] = header_info.height_;

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -220,8 +220,8 @@ public:
             j_ith_sensor["pfnc_pixelformat"] = header_infos[i].pfnc_pixelformat;
             j["sensor" + std::to_string(i+1)] = j_ith_sensor;
         }
-
-        ::std::ofstream config(output_directory_ / "config.json");
+        auto filename = prefix_ + "config.json";
+        std::ofstream config(output_directory_ / filename);
         config << std::setw(4) << j << std::endl;
         config.close();
 

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -210,18 +210,16 @@ public:
        }
 
     void write_config_file(ion::bb::image_io::rawHeader& header_info){
-        nlohmann::json j;
         nlohmann::json j_sensor;
         j_sensor["prefix"] = prefix_;
         j_sensor["framerate"] = header_info.fps_;
         j_sensor["width"] = header_info.width_;
         j_sensor["height"] = header_info.height_;
         j_sensor["pfnc_pixelformat"] = header_info.pfnc_pixelformat;
-        j["sensor"] = j_sensor;
 
         auto filename = prefix_ + "config.json";
         std::ofstream config(output_directory_ / filename);
-        config << std::setw(4) << j << std::endl;
+        config << std::setw(4) << j_sensor << std::endl;
         config.close();
         with_header_ = false;
     }

--- a/src/bb/image-io/rt_file.h
+++ b/src/bb/image-io/rt_file.h
@@ -138,10 +138,10 @@ public:
     }
 
     void post_image(std::vector<void *>& outs, std::vector<size_t>& size,
-                    std::vector<ion::bb::image_io::rawHeader>& header_infos, void* framecounts)
+                    ion::bb::image_io::rawHeader& header_info, void* framecounts)
     {
         if (with_header_){
-            write_config_file(header_infos);
+            write_config_file(header_info);
         }
         ::std::unique_lock<::std::mutex> lock(mutex_);
         buf_cv_.wait(lock, [&] { return !buf_queue_.empty() || ep_; });
@@ -161,10 +161,10 @@ public:
         task_cv_.notify_one();
     }
 
-    void post_gendc(std::vector<void *>& outs, std::vector<size_t>& size, std::vector<ion::bb::image_io::rawHeader>& header_infos)
+    void post_gendc(std::vector<void *>& outs, std::vector<size_t>& size, ion::bb::image_io::rawHeader& header_info)
     {
         if (with_header_){
-            write_config_file(header_infos);
+            write_config_file(header_info);
         }
         ::std::unique_lock<::std::mutex> lock(mutex_);
         buf_cv_.wait(lock, [&] { return !buf_queue_.empty() || ep_; });
@@ -209,22 +209,19 @@ public:
 
        }
 
-    void write_config_file(std::vector<ion::bb::image_io::rawHeader>& header_infos){
+    void write_config_file(ion::bb::image_io::rawHeader& header_info){
         nlohmann::json j;
-        j["num_device"] = header_infos.size();
-        for (int i = 0; i < header_infos.size(); ++i){
-            nlohmann::json j_ith_sensor;
-            j_ith_sensor["framerate"] = header_infos[i].fps_;
-            j_ith_sensor["width"] = header_infos[i].width_;
-            j_ith_sensor["height"] = header_infos[i].height_;
-            j_ith_sensor["pfnc_pixelformat"] = header_infos[i].pfnc_pixelformat;
-            j["sensor" + std::to_string(i+1)] = j_ith_sensor;
-        }
+        nlohmann::json j_sensor;
+        j_sensor["framerate"] = header_info.fps_;
+        j_sensor["width"] = header_info.width_;
+        j_sensor["height"] = header_info.height_;
+        j_sensor["pfnc_pixelformat"] = header_info.pfnc_pixelformat;
+        j["sensor"] = j_sensor;
+
         auto filename = prefix_ + "config.json";
         std::ofstream config(output_directory_ / filename);
         config << std::setw(4) << j << std::endl;
         config.close();
-
         with_header_ = false;
     }
 
@@ -394,13 +391,12 @@ int ion_bb_image_io_binary_gendc_saver( halide_buffer_t * id_buf, halide_buffer_
             return 0;
         }
         else {
-            ion::bb::image_io::rawHeader header_info0;
-            ::memcpy(&header_info0, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
-            std::vector<ion::bb::image_io::rawHeader> header_infos{header_info0};
+            ion::bb::image_io::rawHeader header_info;
+            ::memcpy(&header_info, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
 
             std::vector<void *> obufs{gendc->host};
             std::vector<size_t> size_in_bytes{gendc->size_in_bytes()};
-            w.post_gendc(obufs, size_in_bytes, header_infos);
+            w.post_gendc(obufs, size_in_bytes, header_info);
 
 
         }
@@ -460,13 +456,13 @@ int ion_bb_image_io_binary_image_saver(
         else {
 
 
-            ion::bb::image_io::rawHeader header_info0;
-            ::memcpy(&header_info0, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
-            std::vector<ion::bb::image_io::rawHeader> header_infos{header_info0};
+            ion::bb::image_io::rawHeader header_info;
+            memcpy(&header_info, deviceinfo->host, sizeof(ion::bb::image_io::rawHeader));
+            std::vector<ion::bb::image_io::rawHeader> header_infos{header_info};
 
             std::vector<void *> obufs{image->host};
             std::vector<size_t> size_in_bytes{image->size_in_bytes()};
-            w.post_image(obufs, size_in_bytes, header_infos, frame_count->host);
+            w.post_image(obufs, size_in_bytes, header_info, frame_count->host);
         }
 
         return 0;


### PR DESCRIPTION
Previously, config json will override each other,
Now, 
<img width="371" alt="Screenshot 2024-05-09 at 11 13 48 AM" src="https://github.com/fixstars/ion-kit/assets/143661893/98e111fd-a19f-431e-b4e9-785b9dd24280">
<img width="347" alt="Screenshot 2024-05-09 at 2 18 14 PM" src="https://github.com/fixstars/ion-kit/assets/143661893/3f709644-cb2e-4415-97cd-8bf4a77ee3e8">



```
{

        "framerate": 25.0,
        "height": 480,
        "pfnc_pixelformat": 17301505,
        "width": 640
    
}
```
