### PR TITLE
Fix/cdci

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -57,4 +57,4 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          ctest --verbose -v -C $BUILD_TYPE
+          ctest --verbose -C $BUILD_TYPE

--- a/.github/workflows/macos.yml
+++ b/.github/workflows/macos.yml
@@ -41,4 +41,4 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          ctest --verbose -v -C $BUILD_TYPE
+          ctest --verbose -C $BUILD_TYPE

--- a/.github/workflows/python_publish.yml
+++ b/.github/workflows/python_publish.yml
@@ -33,8 +33,10 @@ jobs:
       - uses: robinraju/release-downloader@v1.9
         with:
           repository: "fixstars/ion-kit"
-          latest: true
+          latest: false
           fileName: "ion-kit*"
+          tag: ${{ github.event.release.tag_name }}
+
 
       - name: Copy macos file
         if: runner.os == 'macOS'

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -50,4 +50,4 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          ctest --verbose -v -C $BUILD_TYPE
+          ctest --verbose -C $BUILD_TYPE


### PR DESCRIPTION
1. cmake update to 29 to 30 so          ~ctest --verbose -v -C $BUILD_TYPE~ to          `ctest --verbose -C $BUILD_TYPE`
2. python package release cdci fix to retrieve specific tag instead latest