### PR TITLE
bind to raw data without generic type

### DIFF
--- a/include/ion/port.h
+++ b/include/ion/port.h
@@ -193,6 +193,19 @@ public:
          impl_->bound_address[i] = std::make_tuple(v, false);
      }
 
+     void bind(Halide::Type typ,void *v) {
+         auto i = index_ == -1 ? 0 : index_;
+
+         if (has_pred()) {
+             impl_->params[i] = Halide::Parameter{typ, false, 0, argument_name(pred_id(), id(), pred_name(), i, graph_id())};
+         } else {
+             impl_->params[i] = Halide::Parameter{type(), false, dimensions(), argument_name(pred_id(), id(), pred_name(), i, graph_id())};
+         }
+
+         impl_->instances[i] = v;
+         impl_->bound_address[i] = std::make_tuple(v, false);
+     }
+
      template<typename T>
      void bind(const Halide::Buffer<T>& buf) {
          auto i = index_ == -1 ? 0 : index_;

--- a/include/ion/port.h
+++ b/include/ion/port.h
@@ -181,16 +181,7 @@ public:
 
      template<typename T>
      void bind(T *v) {
-         auto i = index_ == -1 ? 0 : index_;
-
-         if (has_pred()) {
-             impl_->params[i] = Halide::Parameter{Halide::type_of<T>(), false, 0, argument_name(pred_id(), id(), pred_name(), i, graph_id())};
-         } else {
-             impl_->params[i] = Halide::Parameter{type(), false, dimensions(), argument_name(pred_id(), id(), pred_name(), i, graph_id())};
-         }
-
-         impl_->instances[i] = v;
-         impl_->bound_address[i] = std::make_tuple(v, false);
+         bind(Halide::type_of<T>(),v);
      }
 
      void bind(Halide::Type typ,void *v) {

--- a/include/ion/port.h
+++ b/include/ion/port.h
@@ -181,14 +181,14 @@ public:
 
      template<typename T>
      void bind(T *v) {
-         bind(Halide::type_of<T>(),v);
+         bind(Halide::type_of<T>(), v);
      }
 
-     void bind(Halide::Type typ,void *v) {
+     void bind(Halide::Type target_type, void *v) {
          auto i = index_ == -1 ? 0 : index_;
 
          if (has_pred()) {
-             impl_->params[i] = Halide::Parameter{typ, false, 0, argument_name(pred_id(), id(), pred_name(), i, graph_id())};
+             impl_->params[i] = Halide::Parameter{target_type, false, 0, argument_name(pred_id(), id(), pred_name(), i, graph_id())};
          } else {
              impl_->params[i] = Halide::Parameter{type(), false, dimensions(), argument_name(pred_id(), id(), pred_name(), i, graph_id())};
          }


### PR DESCRIPTION
Port.bind<Generic Type>(T* data) is restrictive to use in certain circumstances.
Adding a Halide::Type as an argument and removing the generic typing helps.

Port.bind(Halide::Type, void* data) allows binding to raw addresses.