### PR TITLE
Fix/acq before stream

### DIFF
--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -922,6 +922,18 @@ private:
                     throw std::runtime_error(err_->message);
                 }
 
+                arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
+                if (err_) {
+                    throw std::runtime_error(err_->message);
+                }
+                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
+                
+                arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
+                if (err_) {
+                    throw std::runtime_error(err_->message);
+                }
+                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
+
                 devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
                 if (err_ ) {
                     throw std::runtime_error(err_->message);
@@ -1072,21 +1084,8 @@ private:
 
             }
 
-            for (auto i=0; i<devices_.size(); ++i) {
-                arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-            }
 
-            for (auto i=0; i<devices_.size(); ++i) {
-                arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
-            }
+
         }
     };
 

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -922,26 +922,6 @@ private:
                     throw std::runtime_error(err_->message);
                 }
 
-                arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-                
-                arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
-
-                devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
-                if (err_ ) {
-                    throw std::runtime_error(err_->message);
-                }
-                if (devices_[i].stream_ == nullptr) {
-                    throw std::runtime_error("stream is null");
-                }
-
                 // check it the device has gendc mode ==============================
                 is_gendc_ = arv_device_is_feature_available(devices_[i].device_, "GenDCDescriptor", &err_);
                 if (err_) {
@@ -1069,6 +1049,27 @@ private:
                     }
                     log::info("\tDevice/USB {}::{} : {}", i, "OperationMode", operation_mode_in_string);
                 }
+
+                arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
+                if (err_) {
+                    throw std::runtime_error(err_->message);
+                }
+                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
+
+                arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
+                if (err_) {
+                    throw std::runtime_error(err_->message);
+                }
+                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
+
+                devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
+                if (err_ ) {
+                    throw std::runtime_error(err_->message);
+                }
+                if (devices_[i].stream_ == nullptr) {
+                    throw std::runtime_error("stream is null");
+                }
+
             }
 
             for (auto i=0; i<devices_.size(); ++i) {
@@ -1414,14 +1415,6 @@ private:
                     throw std::runtime_error(err_->message);
                 }
 
-                devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
-                if (err_ ) {
-                    throw std::runtime_error(err_->message);
-                }
-                if (devices_[i].stream_ == nullptr) {
-                    throw std::runtime_error("stream is null");
-                }
-
                 // check it the device has gendc mode ==============================
                 is_gendc_ = arv_device_is_feature_available(devices_[i].device_, "GenDCDescriptor", &err_);
                 if (err_) {
@@ -1546,6 +1539,27 @@ private:
                     }
                     log::info("\tDevice/USB {}::{} : {}", i, "OperationMode", operation_mode_in_string);
                 }
+
+                arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
+                if (err_) {
+                    throw std::runtime_error(err_->message);
+                }
+                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
+
+                arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
+                if (err_) {
+                    throw std::runtime_error(err_->message);
+                }
+                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
+
+                devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
+                if (err_ ) {
+                    throw std::runtime_error(err_->message);
+                }
+                if (devices_[i].stream_ == nullptr) {
+                    throw std::runtime_error("stream is null");
+                }
+
             }
 
             for (auto i=0; i<devices_.size(); ++i) {
@@ -1561,21 +1575,7 @@ private:
 
             }
 
-            for (auto i=0; i<devices_.size(); ++i) {
-                arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-            }
 
-            for (auto i=0; i<devices_.size(); ++i) {
-                arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
-            }
         }
     };
 

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -89,6 +89,12 @@ protected:
         ARV_DEVICE_STATUS_WRITE_ERROR
     }ArvDeviceStatus_t;
 
+    typedef enum ArvUvUsbMode{
+        ARV_UV_USB_MODE_SYNC,
+        ARV_UV_USB_MODE_ASYNC,
+        ARV_UV_USB_MODE_DEFAULT = ARV_UV_USB_MODE_ASYNC
+    } ArvUvUsbMode_t;
+
     using ArvDevice_t = struct ArvDevice*;
     using ArvFakeDevice_t = struct ArvFakeDevice*;
     using ArvStream_t = struct ArvStream*;
@@ -153,6 +159,8 @@ protected:
     using arv_enable_interface_t = void(*)(const char*);
     using arv_camera_create_stream_t = ArvStream*(*)(ArvCamera*, ArvStreamCallback*, void*, GError**);
     using arv_fake_device_get_fake_camera_t = ArvCamera*(*)(ArvFakeDevice*);
+
+    using arv_uv_device_set_usb_mode_t = void(*)(ArvDevice *, ArvUvUsbMode );
 
     struct DeviceInfo {
         const char* dev_id_;
@@ -412,6 +420,8 @@ protected:
         GET_SYMBOL(arv_set_fake_camera_genicam_filename, "arv_set_fake_camera_genicam_filename");
         GET_SYMBOL(arv_enable_interface, "arv_enable_interface");
         GET_SYMBOL(arv_fake_device_get_fake_camera, "arv_fake_device_get_fake_camera");
+        GET_SYMBOL(arv_uv_device_set_usb_mode, " arv_uv_device_set_usb_mode");
+
         #undef GET_SYMBOL
     }
 
@@ -534,6 +544,8 @@ protected:
     arv_enable_interface_t arv_enable_interface;
     arv_set_fake_camera_genicam_filename_t   arv_set_fake_camera_genicam_filename;
     arv_fake_device_get_fake_camera_t arv_fake_device_get_fake_camera;
+
+    arv_uv_device_set_usb_mode_t arv_uv_device_set_usb_mode;
 
     static std::map<std::string, std::shared_ptr<U3V>> instances_;
 
@@ -908,6 +920,8 @@ private:
                 if (devices_[i].device_ == nullptr) {
                     throw std::runtime_error("device is null");
                 }
+
+                arv_uv_device_set_usb_mode(devices_[i].device_, ARV_UV_USB_MODE_SYNC); //hotfix
 
                 pixel_format_ = arv_device_get_string_feature_value(devices_[i].device_, "PixelFormat", &err_);
                 if (err_ ) {

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -1076,6 +1076,13 @@ private:
                 log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
             }
 
+            /*
+             * ion-kit starts the acquisition before stream creation This is a tentative fix only in ion-kit due to hardware issue
+             * In aravis, the acquisition should be done afterward. Since this maps better with GenAPI, where buffers
+             * must be pushed to DataStream objectsbefore DataStream acquisition is started.
+             * refer to https://github.com/AravisProject/aravis/blob/2ebaa8661761ea4bbc4df878aa67b4a9e1a9a3b9/docs/reference/aravis/porting-0.10.md
+             */
+
             //start streaming after AcquisitionStart
             for (auto i=0; i<devices_.size(); ++i) {
                 devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
@@ -1566,7 +1573,12 @@ private:
                 }
                 log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
             }
-
+            /*
+             * ion-kit starts the acquisition before stream creation This is a tentative fix only in ion-kit due to hardware issue
+             * In aravis, the acquisition should be done afterward. Since this maps better with GenAPI, where buffers
+             * must be pushed to DataStream objectsbefore DataStream acquisition is started.
+             * refer to https://github.com/AravisProject/aravis/blob/2ebaa8661761ea4bbc4df878aa67b4a9e1a9a3b9/docs/reference/aravis/porting-0.10.md
+             */
             for (auto i=0; i<devices_.size(); ++i) {
                 devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
                 if (err_ ) {

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -420,7 +420,7 @@ protected:
         GET_SYMBOL(arv_set_fake_camera_genicam_filename, "arv_set_fake_camera_genicam_filename");
         GET_SYMBOL(arv_enable_interface, "arv_enable_interface");
         GET_SYMBOL(arv_fake_device_get_fake_camera, "arv_fake_device_get_fake_camera");
-        GET_SYMBOL(arv_uv_device_set_usb_mode, " arv_uv_device_set_usb_mode");
+        GET_SYMBOL(arv_uv_device_set_usb_mode, "arv_uv_device_set_usb_mode");
 
         #undef GET_SYMBOL
     }
@@ -666,9 +666,8 @@ private:
         }
 
         // Start streaming and start acquisition
-        devices_[0].stream_ = arv_device_create_stream (devices_[0].device_, NULL, NULL, &err_);
-        if (num_sensor_==2){
-            devices_[1].stream_ = arv_device_create_stream (devices_[1].device_, NULL, NULL, &err_);
+        for (auto i=0; i<devices_.size(); ++i) {
+            devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, NULL, NULL, &err_);
         }
 
         for (auto i=0; i<devices_.size(); ++i) {
@@ -873,10 +872,9 @@ private:
 
             }
 
-            // Start streaming and start acquisition
-            devices_[0].stream_ = arv_device_create_stream (devices_[0].device_, NULL, NULL, &err_);
-            if (num_sensor_==2){
-                devices_[1].stream_ = arv_device_create_stream (devices_[1].device_, NULL, NULL, &err_);
+            // Start streaming and start acquisition for fake camera
+            for (auto i=0; i<devices_.size(); ++i) {
+                devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, NULL, NULL, &err_);
             }
 
             for (auto i=0; i<devices_.size(); ++i) {
@@ -921,7 +919,7 @@ private:
                     throw std::runtime_error("device is null");
                 }
 
-                arv_uv_device_set_usb_mode(devices_[i].device_, ARV_UV_USB_MODE_SYNC); //hotfix
+
 
                 pixel_format_ = arv_device_get_string_feature_value(devices_[i].device_, "PixelFormat", &err_);
                 if (err_ ) {
@@ -955,6 +953,7 @@ private:
                     if (strcmp(device_model_name, "    ")==0){
                         is_param_integer_ = true;
                         frame_count_method_ = FrameCountMethod::TIMESTAMP;
+                        arv_uv_device_set_usb_mode(devices_[i].device_, ARV_UV_USB_MODE_SYNC); //hotfix for v1.0
                     }
                     if (is_gendc_){
                         frame_count_method_ = FrameCountMethod::TYPESPECIFIC3;
@@ -1075,15 +1074,17 @@ private:
                     throw std::runtime_error(err_->message);
                 }
                 log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
+            }
 
+            //start streaming after AcquisitionStart
+            for (auto i=0; i<devices_.size(); ++i) {
                 devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
-                if (err_ ) {
+                if (err_) {
                     throw std::runtime_error(err_->message);
                 }
                 if (devices_[i].stream_ == nullptr) {
                     throw std::runtime_error("stream is null");
                 }
-
             }
 
             for (auto i=0; i<devices_.size(); ++i) {
@@ -1369,9 +1370,8 @@ private:
             }
 
             // Start streaming and start acquisition
-            devices_[0].stream_ = arv_device_create_stream (devices_[0].device_, NULL, NULL, &err_);
-            if (num_sensor_==2){
-                devices_[1].stream_ = arv_device_create_stream (devices_[1].device_, NULL, NULL, &err_);
+            for (auto i=0; i<devices_.size(); ++i) {
+                devices_[i].stream_ = arv_device_create_stream (devices_[i].device_, NULL, NULL, &err_);
             }
 
             for (auto i=0; i<devices_.size(); ++i) {
@@ -1565,7 +1565,9 @@ private:
                     throw std::runtime_error(err_->message);
                 }
                 log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
+            }
 
+            for (auto i=0; i<devices_.size(); ++i) {
                 devices_[i].stream_ = arv_device_create_stream(devices_[i].device_, nullptr, nullptr, &err_);
                 if (err_ ) {
                     throw std::runtime_error(err_->message);
@@ -1573,7 +1575,6 @@ private:
                 if (devices_[i].stream_ == nullptr) {
                     throw std::runtime_error("stream is null");
                 }
-
             }
 
             for (auto i=0; i<devices_.size(); ++i) {


### PR DESCRIPTION
#### Note: 
1. this is a tentative fix for camera v2,  making  arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_); before create_stream    

In aravis the legal process is to  create_stream first and then start Acquisition.

2. set usb to sync if camera v1