### PR TITLE
revert the order change for some devices

### DIFF
--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -1052,18 +1052,6 @@ private:
                     }
                     log::info("\tDevice/USB {}::{} : {}", i, "OperationMode", operation_mode_in_string);
                 }
-
-                arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-
-                arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                if (err_) {
-                    throw std::runtime_error(err_->message);
-                }
-                log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
             }
             /*
              * ion-kit starts the acquisition before stream creation This is a tentative fix only in ion-kit due to hardware issue

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -483,6 +483,23 @@ protected:
         return err_;
     }
 
+    GError* CommandAcquisitionModeContdStart(){
+        for (auto i=0; i<devices_.size(); ++i) {
+            arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
+            if (err_) {
+                throw std::runtime_error(err_->message);
+            }
+            log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
+
+            arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
+            if (err_) {
+                throw std::runtime_error(err_->message);
+            }
+            log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
+        }
+        return err_;
+    }
+
     g_object_unref_t g_object_unref;
 
     arv_get_major_version_t arv_get_major_version;
@@ -1059,19 +1076,7 @@ private:
              * refer to https://github.com/AravisProject/aravis/blob/2ebaa8661761ea4bbc4df878aa67b4a9e1a9a3b9/docs/reference/aravis/porting-0.10.md
              */
             if (order_filp_){
-                for (auto i=0; i<devices_.size(); ++i) {
-                    arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-
-                    arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
-                }
+                err_ = CommandAcquisitionModeContdStart();
             }
             //start streaming after AcquisitionStart
             for (auto i=0; i<devices_.size(); ++i) {
@@ -1085,19 +1090,7 @@ private:
             }
 
             if (! order_filp_){
-                for (auto i=0; i<devices_.size(); ++i) {
-                    arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-
-                    arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
-                }
+                err_ = CommandAcquisitionModeContdStart();
             }
 
             for (auto i=0; i<devices_.size(); ++i) {
@@ -1570,19 +1563,7 @@ private:
              * refer to https://github.com/AravisProject/aravis/blob/2ebaa8661761ea4bbc4df878aa67b4a9e1a9a3b9/docs/reference/aravis/porting-0.10.md
              */
             if (order_filp_){
-                for (auto i=0; i<devices_.size(); ++i) {
-                    arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-
-                    arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
-                }
+                err_ = CommandAcquisitionModeContdStart();
             }
             //start streaming after AcquisitionStart
             for (auto i=0; i<devices_.size(); ++i) {
@@ -1596,19 +1577,7 @@ private:
             }
 
             if (! order_filp_){
-                for (auto i=0; i<devices_.size(); ++i) {
-                    arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionMode");
-
-                    arv_device_execute_command(devices_[i].device_, "AcquisitionStart", &err_);
-                    if (err_) {
-                        throw std::runtime_error(err_->message);
-                    }
-                    log::info("\tDevice/USB {}::{} : {}", i, "Command", "AcquisitionStart");
-                }
+                err_ = CommandAcquisitionModeContdStart();
             }
 
             for (auto i=0; i<devices_.size(); ++i) {

--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -331,7 +331,7 @@ protected:
     : gobject_(GOBJECT_FILE, true), aravis_(ARAVIS_FILE, true),
         num_sensor_(num_sensor), frame_count_method_(FrameCountMethod::UNAVAILABLE),
         frame_sync_(frame_sync), realtime_display_mode_(realtime_display_mode), is_gendc_(false), is_param_integer_(false),
-        devices_(num_sensor), buffers_(num_sensor), operation_mode_(OperationMode::Came1USB1), frame_cnt_(0), device_idx_(-1), disposed_(false), sim_mode_(sim_mode)
+        devices_(num_sensor), buffers_(num_sensor), operation_mode_(OperationMode::Came1USB1), frame_cnt_(0), device_idx_(-1), disposed_(false), sim_mode_(sim_mode), order_filp_(false)
     {
         init_symbols();
         log::debug("U3V:: 24-08-29 : revert the order of AcquisitionStart and create stream as a default");
@@ -572,7 +572,7 @@ protected:
     bool disposed_;
     bool sim_mode_;
 
-
+    bool order_filp_;
 
 }; // class U3V
 
@@ -877,7 +877,6 @@ private:
                 log::info("\tFake Device {}::{} : {}", i, "Command", "AcquisitionStart");
             }
         }else{
-            bool order_filp = false;
             if (num_device < num_sensor_){
                 log::info("{} device is found; but the num_sensor is set to {}", num_device, num_sensor_);
                 throw std::runtime_error("Device number is not match, please set num_device again");
@@ -951,7 +950,7 @@ private:
                     }
                     if (is_gendc_){
                         frame_count_method_ = FrameCountMethod::TYPESPECIFIC3;
-                        order_filp = true;
+                        order_filp_ = true;
                     }
                 }
                 log::info("\tDevice/USB {}::{} : {}", i, "frame_count method is ",
@@ -1059,7 +1058,7 @@ private:
              * must be pushed to DataStream objectsbefore DataStream acquisition is started.
              * refer to https://github.com/AravisProject/aravis/blob/2ebaa8661761ea4bbc4df878aa67b4a9e1a9a3b9/docs/reference/aravis/porting-0.10.md
              */
-            if (order_filp){
+            if (order_filp_){
                 for (auto i=0; i<devices_.size(); ++i) {
                     arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
                     if (err_) {
@@ -1085,7 +1084,7 @@ private:
                 }
             }
 
-            if (! order_filp){
+            if (! order_filp_){
                 for (auto i=0; i<devices_.size(); ++i) {
                     arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
                     if (err_) {
@@ -1391,7 +1390,6 @@ private:
                 log::info("\tFake Device {}::{} : {}", i, "Command", "AcquisitionStart");
             }
         }else{
-            bool order_filp = false;
             if (num_sensor < num_sensor_){
                 log::info("{} camera is found; but the number is set to {}", num_sensor, num_sensor_);
                 throw std::runtime_error("Device number is not match, please set num_device again");
@@ -1475,7 +1473,7 @@ private:
                     }
                     if (is_gendc_){
                         frame_count_method_ = FrameCountMethod::TYPESPECIFIC3;
-                        order_filp = true;
+                        order_filp_ = true;
                     }
                 }
                 log::info("\tDevice/USB {}::{} : {}", i, "frame_count method is ",
@@ -1571,7 +1569,7 @@ private:
              * must be pushed to DataStream objectsbefore DataStream acquisition is started.
              * refer to https://github.com/AravisProject/aravis/blob/2ebaa8661761ea4bbc4df878aa67b4a9e1a9a3b9/docs/reference/aravis/porting-0.10.md
              */
-            if (order_filp){
+            if (order_filp_){
                 for (auto i=0; i<devices_.size(); ++i) {
                     arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
                     if (err_) {
@@ -1597,7 +1595,7 @@ private:
                 }
             }
 
-            if (! order_filp){
+            if (! order_filp_){
                 for (auto i=0; i<devices_.size(); ++i) {
                     arv_device_set_string_feature_value(devices_[i].device_, "AcquisitionMode", arv_acquisition_mode_to_string(ARV_ACQUISITION_MODE_CONTINUOUS), &err_);
                     if (err_) {


### PR DESCRIPTION
The change of https://github.com/fixstars/ion-kit/pull/317 resolved some devices' issue, but caused another device's issue. We follow the policy of Aravis: "acquisition is not started automatically at stream creation, but should be done afterward" (https://github.com/AravisProject/aravis/blob/2ebaa8661761ea4bbc4df878aa67b4a9e1a9a3b9/docs/reference/aravis/porting-0.10.md) for the default devices.

|                                        | basler | device 1.0 | device 1.2 |
|----------------------------------------|--------|------------|------------|
| aravis internal-0.8.30 + ion-kit 1.6.2 | PASSED| ERROR|ERROR|
| aravis 0.8.31 + ion-kit BEFORE flip the order of ACQ and create stream         | PASSED | PASSED | ERROR |
| aravis 0.8.31 + ion-kit 3.1.0  AFTER flip the order of ACQ and create stream|FAILED|PASSED | PASSED |