### PR TITLE
skip a single invalid framecount

### DIFF
--- a/src/bb/image-io/rt_u3v.h
+++ b/src/bb/image-io/rt_u3v.h
@@ -898,42 +898,41 @@ protected:
         }
     }
 
-    uint32_t skip_invalid_framecount_0xFFFFFFFF(std::vector<ArvBuffer *>& bufs, uint32_t latest_cnt, int32_t timeout_us){
-        
+    uint32_t skip_invalid_framecount_0xFFFFFFFF(std::vector<ArvBuffer *> &bufs, uint32_t latest_cnt, int32_t timeout_us) {
+
         uint32_t new_latest_cnt = 0;
 
-        int32_t tmp_sig = 0;;
-        memcpy (&tmp_sig, ((char *) arv_buffer_get_data(bufs[device_idx_], nullptr)), sizeof(int32_t));
-        
-        if (tmp_sig == 0xFFFFFFFF){
+        int32_t tmp_sig = 0;
+        ;
+        memcpy(&tmp_sig, ((char *)arv_buffer_get_data(bufs[device_idx_], nullptr)), sizeof(int32_t));
+
+        if (tmp_sig == 0xFFFFFFFF) {
             log::trace("GNDC signature with framecount 0xFFFFFFFF: {} ... let's take it again", tmp_sig);
             bufs[device_idx_] = arv_stream_timeout_pop_buffer(devices_[device_idx_].stream_, timeout_us);
             if (bufs[device_idx_] == nullptr) {
                 log::error("pop_buffer(L11) failed due to timeout ({}s)", timeout_us * 1e-6f);
                 throw ::std::runtime_error("buffer is null");
             }
-            devices_[device_idx_].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3
-                ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[device_idx_], devices_[device_idx_]))
-                : frame_count_method_ == FrameCountMethod::TIMESTAMP
-                ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[device_idx_]) & 0x00000000FFFFFFFF)
-                : -1;
+            devices_[device_idx_].frame_count_ = frame_count_method_ == FrameCountMethod::TYPESPECIFIC3 ? static_cast<uint32_t>(get_frame_count_from_genDC_descriptor(bufs[device_idx_], devices_[device_idx_])) : frame_count_method_ == FrameCountMethod::TIMESTAMP ? static_cast<uint32_t>(arv_buffer_get_timestamp(bufs[device_idx_]) & 0x00000000FFFFFFFF) :
+                                                                                                                                                                                                                                                                        -1;
             new_latest_cnt = devices_[device_idx_].frame_count_;
             device_idx_ == 0 ?
-            log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[device_idx_].frame_count_, "") :
-            log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[device_idx_].frame_count_);
-            tmp_sig = 0;;
-            memcpy (&tmp_sig, ((char *) arv_buffer_get_data(bufs[device_idx_], nullptr)), sizeof(int32_t));
+                log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[device_idx_].frame_count_, "") :
+                log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[device_idx_].frame_count_);
+            tmp_sig = 0;
+            ;
+            memcpy(&tmp_sig, ((char *)arv_buffer_get_data(bufs[device_idx_], nullptr)), sizeof(int32_t));
 
-            if (new_latest_cnt == 0xFFFFFFFF){
+            if (new_latest_cnt == 0xFFFFFFFF) {
                 log::error("pop_buffer(L12) failed due to sequential invalid framecount {}", latest_cnt, tmp_sig);
                 throw ::std::runtime_error("buffer is null");
             }
 
             return new_latest_cnt;
-        }else{
+        } else {
             log::error("pop_buffer(L13) failed due to invalid framecount {} with signature {}", latest_cnt, tmp_sig);
             throw ::std::runtime_error("buffer is null");
-        }   
+        }
     }
 
     g_object_unref_t g_object_unref;
@@ -1177,7 +1176,7 @@ public:
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[device_idx_].frame_count_, "") :
                     log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[device_idx_].frame_count_);
 
-                if (latest_cnt == 0xFFFFFFFF && frame_count_method_ == FrameCountMethod::TYPESPECIFIC3 ){
+                if (latest_cnt == 0xFFFFFFFF && frame_count_method_ == FrameCountMethod::TYPESPECIFIC3) {
                     latest_cnt = skip_invalid_framecount_0xFFFFFFFF(bufs, latest_cnt, timeout_us);
                 }
 
@@ -1330,7 +1329,7 @@ public:
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", devices_[device_idx_].frame_count_, "") :
                 log::trace("All-Popped Frames (USB0, USB1)=({:20}, {:20})", "", devices_[device_idx_].frame_count_);
 
-            if (latest_cnt == 0xFFFFFFFF && frame_count_method_ == FrameCountMethod::TYPESPECIFIC3 ){
+            if (latest_cnt == 0xFFFFFFFF && frame_count_method_ == FrameCountMethod::TYPESPECIFIC3) {
                 latest_cnt = skip_invalid_framecount_0xFFFFFFFF(bufs, latest_cnt, timeout_us);
             }
 


### PR DESCRIPTION
For Came1USB2, device1.2 always send 0xFF filled U3V Payload in the first run. We skip this single frame as a workaround.

## image

```
[2024-10-31 00:32:02.322] [ion] [trace] All-Popped Frames (USB0, USB1)=(                 984,                     )
[2024-10-31 00:32:02.323] [ion] [trace] Obtained Frame from USB0: 984
[2024-10-31 00:32:02.369] [ion] [trace] All-Popped Frames (USB0, USB1)=(                    ,           4294967295)
[2024-10-31 00:32:02.370] [ion] [trace] GNDC signature with framecount 0xFFFFFFFF:  -1 ... let's take it again
[2024-10-31 00:32:02.370] [ion] [trace] All-Popped Frames (USB0, USB1)=(                    ,                  985)
[2024-10-31 00:32:02.371] [ion] [trace] Obtained Frame from USB1: 985
[2024-10-31 00:32:02.383] [ion] [trace] All-Popped Frames (USB0, USB1)=(                 986,                     )
[2024-10-31 00:32:02.384] [ion] [trace] Obtained Frame from USB0: 986
...
```

## GenDC

```
[2024-10-31 00:34:46.325] [ion] [trace] All-Popped Frames (USB0, USB1)=(                2602,                     )
[2024-10-31 00:34:46.326] [ion] [trace] Obtained Frame from USB0: 2602
[2024-10-31 00:34:46.327] [ion] [trace] Obtained Device info (OperationMode::Came1USB2)
[2024-10-31 00:34:46.333] [ion] [trace] All-Popped Frames (USB0, USB1)=(                    ,           4294967295)
[2024-10-31 00:34:46.334] [ion] [trace] GNDC signature with framecount 0xFFFFFF:  -1 ... let's take it again
[2024-10-31 00:34:46.335] [ion] [trace] All-Popped Frames (USB0, USB1)=(                    ,                 2603)
[2024-10-31 00:34:46.336] [ion] [trace] Obtained Frame from USB1: 2603
[2024-10-31 00:34:46.336] [ion] [trace] Obtained Device info (OperationMode::Came1USB2)
[2024-10-31 00:34:46.359] [ion] [trace] All-Popped Frames (USB0, USB1)=(                2604,                   )
[2024-10-31 00:34:46.360] [ion] [trace] Obtained Frame from USB0: 2604
[2024-10-31 00:34:46.360] [ion] [trace] Obtained Device info (OperationMode::Came1USB2)
[2024-10-31 00:34:46.363] [ion] [trace] All-Popped Frames (USB0, USB1)=(                    ,                 2605)
[2024-10-31 00:34:46.365] [ion] [trace] Obtained Frame from USB1: 2605
...
```