### PR TITLE
(WIP) Fix binary loader

### DIFF
--- a/src/bb/image-io/bb.h
+++ b/src/bb/image-io/bb.h
@@ -1085,7 +1085,7 @@ public:
     BuildingBlockParam<std::string> output_directory_ptr{"output_directory", "."};
     BuildingBlockParam<std::string> prefix_ptr{"prefix", "raw-"};
 
-    Input<Halide::Func> input_images{"input", Halide::type_of<T>(), D};
+    Input<Halide::Func> input_image{"input", Halide::type_of<T>(), D};
     Input<Halide::Func> input_deviceinfo{"input_deviceinfo", Halide::type_of<uint8_t>(), 1};
     Input<Halide::Func> frame_count{"frame_count", Halide::type_of<uint32_t>(), 1};
     Input<int32_t> width{"width"};
@@ -1116,7 +1116,7 @@ public:
         Buffer<uint8_t> id_buf = this->get_id();
 
         Func image;
-        image(_) = input_images(_);
+        image(_) = input_image(_);
         image.compute_root();
 
         Func deviceinfo;
@@ -1184,41 +1184,60 @@ public:
 
 class BinaryLoader : public ion::BuildingBlock<BinaryLoader> {
 public:
-    BuildingBlockParam<std::string> output_directory_ptr{"output_directory_ptr", ""};
-    Input<int32_t> width{"width", 0};
-    Input<int32_t> height{"height", 0};
-    Output<Halide::Func> output0{"output0", UInt(16), 2};
-    Output<Halide::Func> output1{"output1", UInt(16), 2};
+    BuildingBlockParam<std::string> output_directory_ptr{"output_directory", ""};
+    BuildingBlockParam<std::string> prefix_ptr{"prefix", "raw-"};
+    BuildingBlockParam<int32_t> width{"width", 640};
+    BuildingBlockParam<int32_t> height{"height", 480};
+
+    Output<Halide::Func> output{"output", UInt(16), 2};
     Output<Halide::Func> finished{"finished", UInt(1), 1};
     Output<Halide::Func> bin_idx{"bin_idx", UInt(32), 1};
+    Output<Halide::Func> frame_count{"frame_count", UInt(32), 1};
 
     void generate() {
         using namespace Halide;
-
-        std::string session_id = sole::uuid4().str();
-        Buffer<uint8_t> session_id_buf(static_cast<int>(session_id.size() + 1));
-        session_id_buf.fill(0);
-        std::memcpy(session_id_buf.data(), session_id.c_str(), session_id.size());
-
-        const std::string output_directory(output_directory_ptr);
-        Halide::Buffer<uint8_t> output_directory_buf(static_cast<int>(output_directory.size() + 1));
-        output_directory_buf.fill(0);
-        std::memcpy(output_directory_buf.data(), output_directory.c_str(), output_directory.size());
-
-        std::vector<ExternFuncArgument> params = {session_id_buf, width, height, output_directory_buf};
         Func binaryloader;
-        binaryloader.define_extern("binaryloader", params, {UInt(16), UInt(16)}, 2);
-        binaryloader.compute_root();
-        output0(_) = binaryloader(_)[0];
-        output1(_) = binaryloader(_)[1];
+
+        {
+            Buffer<uint8_t> id_buf = this->get_id();
+            const std::string output_directory(output_directory_ptr);
+            Halide::Buffer<uint8_t> output_directory_buf(static_cast<int>(output_directory.size() + 1));
+            output_directory_buf.fill(0);
+            std::memcpy(output_directory_buf.data(), output_directory.c_str(), output_directory.size());
+
+            const std::string prefix(prefix_ptr);
+            Halide::Buffer<uint8_t> prefix_buf(static_cast<int>(prefix.size() + 1));
+            prefix_buf.fill(0);
+            std::memcpy(prefix_buf.data(), prefix.c_str(), prefix.size());
+
+            std::vector<ExternFuncArgument> params = {id_buf, static_cast<int32_t>(width), static_cast<int32_t>(height), output_directory_buf ,prefix_buf};
+
+            binaryloader.define_extern("binaryloader", params, UInt(16), 2);
+            binaryloader.compute_root();
+            output(_) = binaryloader(_);
+        }
 
         Func binaryloader_finished;
-        binaryloader_finished.define_extern("binaryloader_finished",
-                                            {binaryloader, session_id_buf, width, height, output_directory_buf},
-                                            {type_of<bool>(), UInt(32)}, 1);
-        binaryloader_finished.compute_root();
-        finished(_) = binaryloader_finished(_)[0];
-        bin_idx(_) = binaryloader_finished(_)[1];
+        {
+            Buffer<uint8_t> id_buf = this->get_id();
+            const std::string prefix(prefix_ptr);
+            Halide::Buffer<uint8_t> prefix_buf(static_cast<int>(prefix.size() + 1));
+            prefix_buf.fill(0);
+            std::memcpy(prefix_buf.data(), prefix.c_str(), prefix.size());
+
+            const std::string output_directory(output_directory_ptr);
+            Halide::Buffer<uint8_t> output_directory_buf(static_cast<int>(output_directory.size() + 1));
+            output_directory_buf.fill(0);
+            std::memcpy(output_directory_buf.data(), output_directory.c_str(), output_directory.size());
+            binaryloader_finished.define_extern("binaryloader_finished",
+                                                  {binaryloader, id_buf, static_cast<int32_t>(width), static_cast<int32_t>(height), output_directory_buf, prefix_buf},
+                                                  {type_of<bool>(), UInt(32),UInt(32)}, 1);
+            binaryloader_finished.compute_root();
+            finished(_) = binaryloader_finished(_)[0];
+            bin_idx(_) = binaryloader_finished(_)[1];
+            frame_count(_) = binaryloader_finished(_)[2];
+        }
+        this->register_disposer("reader_dispose");
     }
 };
 


### PR DESCRIPTION
there are 
1. replace `::std:: `to `std::`
2. fix logic , rewrite reader since reader used to read  bin file that includes header file followed with  framecount  and 2 images

**before**

```
header (512)
framecount
image0
image1
framecount
image0
image1
........

```
 Now it only have frame count and 1 image


**before**

```
framecount
image
framecount
image
........


3.  Fix BinaryLoader
That is en error comes from halide when building the pipeline
```
Error: All Params and embedded Buffers must have unique names, but the name 'b3' was seen multiple times.
```
fix it by not using shared paramers.

